### PR TITLE
Add hard clues 2722, 23176, 23177, 23180

### DIFF
--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -541,11 +541,12 @@ public enum Clues
 	HARD_19902("ZSBKDO ZODO.", ItemID.CLUE_SCROLL_HARD_19902, ClueTier.HARD, List.of(new WorldPoint(3680, 3537, 0))),
 	HARD_23174("Play 'Scorpia Dances' for Cecilia.", ItemID.CLUE_SCROLL_HARD_23174, ClueTier.HARD, List.of(new WorldPoint(2990, 3383, 0))),
 	HARD_23175("Play 'Complication' for Cecilia.", ItemID.CLUE_SCROLL_HARD_23175, ClueTier.HARD, List.of(new WorldPoint(2990, 3383, 0))),
-	// CLUE_SCROLL_HARD_23176
-	// CLUE_SCROLL_HARD_23177
+	HARD_2722("A crate in the Lumber Yard, north-east of Varrock.", ItemID.CLUE_SCROLL_HARD, ClueTier.HARD, List.of(new WorldPoint(3309, 3503, 0))),
+	HARD_23176("Play 'Subterranea' for Cecilia.", ItemID.CLUE_SCROLL_HARD_23176, ClueTier.HARD, List.of(new WorldPoint(2990, 3383, 0))),
+	HARD_23177("Play 'Little Cave of Horrors' for Cecilia.", ItemID.CLUE_SCROLL_HARD_23177, ClueTier.HARD, List.of(new WorldPoint(2990, 3383, 0))),
+	HARD_23180("Play 'Fossilised' for Cecilia.", ItemID.CLUE_SCROLL_HARD_23180, ClueTier.HARD, List.of(new WorldPoint(2990, 3383, 0))),
 	// CLUE_SCROLL_HARD_23178
 	// CLUE_SCROLL_HARD_23179
-	// CLUE_SCROLL_HARD_23180
 	// CLUE_SCROLL_HARD_23181
 
 	// CLUE_SCROLL_HARD_25792

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -545,9 +545,9 @@ public enum Clues
 	HARD_23176("Play 'Subterranea' for Cecilia.", ItemID.CLUE_SCROLL_HARD_23176, ClueTier.HARD, List.of(new WorldPoint(2990, 3383, 0))),
 	HARD_23177("Play 'Little Cave of Horrors' for Cecilia.", ItemID.CLUE_SCROLL_HARD_23177, ClueTier.HARD, List.of(new WorldPoint(2990, 3383, 0))),
 	HARD_23180("Play 'Fossilised' for Cecilia.", ItemID.CLUE_SCROLL_HARD_23180, ClueTier.HARD, List.of(new WorldPoint(2990, 3383, 0))),
+	HARD_23181("Play 'Hells Bells' for Cecilia.", ItemID.CLUE_SCROLL_HARD_23181, ClueTier.HARD, List.of(new WorldPoint(2990, 3383, 0))),
 	// CLUE_SCROLL_HARD_23178
 	// CLUE_SCROLL_HARD_23179
-	// CLUE_SCROLL_HARD_23181
 
 	// CLUE_SCROLL_HARD_25792
 	// CLUE_SCROLL_HARD_3577


### PR DESCRIPTION
Adds "Subterranea", "Little Cave of Horros", and "Fossilised" Cecilia music track steps for hard clues as well as the search the crate in the Lumber Yard step for hard clues

| Clue ID | Clue | Image |
|--------|--------|--------|
| 2722 | Crate: Lumber Yard | <details><summary>Clue Image</summary>![image](https://i.imgur.com/2bIczIz.png)</details> |
| 23176 | Music: _Subterranea_ | <details><summary>Clue Image</summary>![image](https://i.imgur.com/H4fvoOy.png)</details> |
| 23177 | Music: _Little Cave of Horrors_ | <details><summary>Clue Image</summary>![image](https://i.imgur.com/TVfv2tP.png)</details> |
| 23180 | Music: _Fossilised_ | <details><summary>Clue Image</summary>![image](https://i.imgur.com/WTTv6FR.png)</details> |
| 23181 | Music: _Hells Bells_ | <details><summary>Clue Image</summary>![image](https://i.imgur.com/KaZM4rv.png)</details> |


Note, I forgot to hover over the clue for 23177 to confirm the item id in the image. I'm 99% sure it was 23177. The ID is also inline with the other music clue ids. If you want me to be 100% sure you can delay the merge as I'm juggling 15 hard clues right now, but so far none of them were 23177. ~~I'm not sure when I'll do them, but if I get the 23177 clue again then I'll confirm it here.~~ EDIT: I didn't get that clue again.

Oh, and also I made these changes after completing the clues so I couldn't test them FWIW.