### PR TITLE
feat: Allow personalised text on clues

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -223,7 +223,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 			return "Can't determine clue.";
 		}
 
-		return matchingClue.getClueText();
+		return matchingClue.getDisplayText(configManager);
 	}
 
 	@Subscribe

--- a/src/main/java/com/cluedetails/ClueDetailsPanel.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPanel.java
@@ -88,7 +88,7 @@ public class ClueDetailsPanel extends PluginPanel
 			BorderFactory.createMatteBorder(1, 0, 1, 0, ColorScheme.DARK_GRAY_COLOR.brighter()),
 			BorderFactory.createEmptyBorder(5, 5, 10, 0)
 		));
-		panel.setText(generateText(clue.getClueText()));
+		panel.setText(generateText(clue.getDisplayText(configManager)));
 		panel.setOpaque(true);
 		boolean isActive = clueStates.getOrDefault(clue.getClueID(), false);
 		panel.setBackground(isActive ? Color.GREEN.darker() : Color.RED.darker());

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -40,6 +40,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.game.chatbox.ChatboxPanelManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
@@ -74,6 +75,9 @@ public class ClueDetailsPlugin extends Plugin
 	private ClientToolbar clientToolbar;
 
 	@Inject
+	private ChatboxPanelManager chatboxPanelManager;
+
+	@Inject
 	ConfigManager configManager;
 
 	ClueDetailsParentPanel panel;
@@ -94,7 +98,7 @@ public class ClueDetailsPlugin extends Plugin
 
 		final BufferedImage icon = ImageUtil.loadImageResource(ClueDetailsPlugin.class, "/icon.png");
 
-		panel = new ClueDetailsParentPanel(configManager, cluePreferenceManager, config);
+		panel = new ClueDetailsParentPanel(configManager, cluePreferenceManager, config, chatboxPanelManager);
 		navButton = NavigationButton.builder()
 			.tooltip("Clue Details")
 			.icon(icon)

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -30,6 +30,7 @@ import java.util.List;
 import lombok.Getter;
 import net.runelite.api.ItemID;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.config.ConfigManager;
 
 @Getter
 public enum Clues
@@ -784,5 +785,12 @@ public enum Clues
 			}
 		}
 		return null;
+	}
+
+	public String getDisplayText(ConfigManager configManager)
+	{
+		String text = configManager.getConfiguration("clue-details-text", String.valueOf(getClueID()));
+		if (text != null) return text;
+		return getClueText();
 	}
 }

--- a/src/main/java/com/cluedetails/panels/ClueDetailsParentPanel.java
+++ b/src/main/java/com/cluedetails/panels/ClueDetailsParentPanel.java
@@ -49,6 +49,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.chatbox.ChatboxPanelManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.IconTextField;
@@ -66,6 +67,8 @@ public class ClueDetailsParentPanel extends PluginPanel
 
 	private ConfigManager configManager;
 
+	private ChatboxPanelManager chatboxPanelManager;
+
 	private CluePreferenceManager cluePreferenceManager;
 	private final ClueDetailsConfig config;
 
@@ -75,13 +78,14 @@ public class ClueDetailsParentPanel extends PluginPanel
 	private final JPanel allDropdownSections = new JPanel();
 
 
-	public ClueDetailsParentPanel(ConfigManager configManager, CluePreferenceManager cluePreferenceManager, ClueDetailsConfig config)
+	public ClueDetailsParentPanel(ConfigManager configManager, CluePreferenceManager cluePreferenceManager, ClueDetailsConfig config, ChatboxPanelManager chatboxPanelManager)
 	{
 		super(false);
 
 		this.configManager = configManager;
 		this.cluePreferenceManager = cluePreferenceManager;
 		this.config = config;
+		this.chatboxPanelManager = chatboxPanelManager;
 
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 		setLayout(new BorderLayout());
@@ -267,7 +271,7 @@ public class ClueDetailsParentPanel extends PluginPanel
 			}
 			for (Clues clue : filterList)
 			{
-				clueSelectLabels.add(new ClueSelectLabel(cluePreferenceManager, clue));
+				clueSelectLabels.add(new ClueSelectLabel(cluePreferenceManager, clue, chatboxPanelManager, configManager));
 			}
 		}
 

--- a/src/main/java/com/cluedetails/panels/ClueSelectLabel.java
+++ b/src/main/java/com/cluedetails/panels/ClueSelectLabel.java
@@ -29,15 +29,23 @@ import com.cluedetails.Clues;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.chatbox.ChatboxPanelManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
 
@@ -46,6 +54,10 @@ public class ClueSelectLabel extends JLabel
 	final CluePreferenceManager cluePreferenceManager;
 	final Clues clue;
 
+	ChatboxPanelManager chatboxPanelManager;
+
+	ConfigManager configManager;
+
 	private static final Border SELECTED_BORDER = new CompoundBorder(
 		BorderFactory.createMatteBorder(0, 0, 1, 0, ColorScheme.BRAND_ORANGE),
 		BorderFactory.createEmptyBorder(5, 10, 4, 10));
@@ -53,15 +65,18 @@ public class ClueSelectLabel extends JLabel
 	private static final Border UNSELECTED_BORDER = BorderFactory
 		.createEmptyBorder(5, 10, 5, 10);
 
-	public ClueSelectLabel(CluePreferenceManager cluePreferenceManager, Clues clue)
+	public ClueSelectLabel(CluePreferenceManager cluePreferenceManager, Clues clue,
+						   ChatboxPanelManager chatboxPanelManager, ConfigManager configManager)
 	{
 		this.cluePreferenceManager = cluePreferenceManager;
 		this.clue = clue;
+		this.chatboxPanelManager = chatboxPanelManager;
+		this.configManager = configManager;
 
 		setLayout(new BorderLayout());
 		setHorizontalAlignment(SwingConstants.LEFT);
 		setVerticalAlignment(SwingConstants.TOP);
-		setText(generateText(clue.getClueText()));
+		setText(generateText(clue.getDisplayText(configManager)));
 		setOpaque(true);
 		boolean isActive = cluePreferenceManager.getPreference(clue.getClueID());
 		setSelected(isActive);
@@ -72,6 +87,11 @@ public class ClueSelectLabel extends JLabel
 			@Override
 			public void mousePressed(MouseEvent e)
 			{
+				if (SwingUtilities.isRightMouseButton(e))
+				{
+					showPopupMenu(e);
+				}
+
 				if (e.getButton() != MouseEvent.BUTTON1) return;
 
 				boolean currentState = cluePreferenceManager.getPreference(clue.getClueID());
@@ -93,6 +113,29 @@ public class ClueSelectLabel extends JLabel
 				setHovered(false);
 			}
 		});
+	}
+
+	private void showPopupMenu(MouseEvent e)
+	{
+		JPopupMenu popupMenu = new JPopupMenu();
+
+		JMenuItem inputItem = new JMenuItem("Edit text for clue");
+		inputItem.addActionListener(new ActionListener()
+		{
+			@Override
+			public void actionPerformed(ActionEvent event)
+			{
+				chatboxPanelManager.openTextInput("Enter new clue name:")
+					.onDone((newTag) -> {
+						configManager.setConfiguration("clue-details-text", String.valueOf(clue.getClueID()), newTag);
+						setText(generateText(clue.getDisplayText(configManager)));
+					})
+					.build();
+			}
+		});
+
+		popupMenu.add(inputItem);
+		popupMenu.show(e.getComponent(), e.getX(), e.getY());
 	}
 
 	public ClueSelectLabel(String text)
@@ -118,7 +161,7 @@ public class ClueSelectLabel extends JLabel
 	public List<String> getKeywords()
 	{
 		if (clue == null) return List.of();
-		return Arrays.asList(clue.getClueText().toLowerCase().split(" "));
+		return Arrays.asList(clue.getDisplayText(configManager).toLowerCase().split(" "));
 	}
 
 	private void setSelected(boolean isSelected)


### PR DESCRIPTION
This adds personalised text for clues, which can be set by right-clicking a clue in the sidebar.


https://github.com/user-attachments/assets/3de77af3-4f79-4cf3-b5ff-6725203ca526

