### PR TITLE
feat: Added clue IDs to clue keywords for search

### DIFF
--- a/src/main/java/com/cluedetails/panels/ClueDetailsParentPanel.java
+++ b/src/main/java/com/cluedetails/panels/ClueDetailsParentPanel.java
@@ -220,7 +220,12 @@ public class ClueDetailsParentPanel extends PluginPanel
 
 		clueSelectLabels.forEach(listItem ->
 		{
-			if (Text.matchesSearchTerms(Arrays.asList(searchTerms), listItem.getKeywords()))
+			List<String> keywords = new ArrayList<>(listItem.getKeywords());
+			if (listItem.clue != null)
+			{
+				keywords.add(Integer.toString(listItem.clue.getClueID()));
+			}
+			if (Text.matchesSearchTerms(Arrays.asList(searchTerms), keywords))
 			{
 				clueListPanel.add(listItem);
 			}


### PR DESCRIPTION
Adds a clue's ID to the search terms, to make it easier to find specific clues by ID.

![Screenshot 2024-09-01 220640](https://github.com/user-attachments/assets/2d47ff0c-e7e2-4609-b7b9-472603c9c91c)
