### PR TITLE
feat: Allow clue text to be changed to hint info

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -259,6 +259,17 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "changeClueText",
+		name = "Change clue item text",
+		description = "Toggle whether to make the clue item text be the hint or the normal text",
+		position = 5
+	)
+	default boolean changeClueText()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 			keyName = "highlightFeather",
 			name = "Highlighted feathering",
 			description = "Configure the feathering of highlighted clues",

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -154,6 +154,20 @@ public class ClueDetailsOverlay extends OverlayPanel
 
 			int numberNotInMainMenu = 0;
 
+			if (config.changeClueText())
+			{
+				// Change text of actual clue
+				for (int i = currentMenuEntries.length - 1; i >= 0; i--)
+				{
+					MenuEntry hoveredEntry = currentMenuEntries[i];
+					Clues clue = Clues.get(hoveredEntry.getIdentifier());
+					if (clue != null)
+					{
+						hoveredEntry.setTarget("<col=ff9146>" + clue.getDisplayText(configManager) + "<col=FFA07A>");
+					}
+				}
+			}
+
 			for (int i = currentMenuEntries.length - 1; i >= 0; i--)
 			{
 				MenuEntry hoveredEntry = currentMenuEntries[i];


### PR DESCRIPTION
This adds an optional toggle for whether to replace clue text with the clue hints.

![Screenshot 2024-09-01 221408](https://github.com/user-attachments/assets/86031a3e-517c-4482-909a-b4bf0412a225)
