### PR TITLE
feat: Added item tags, edit via inventory toggle, config cleanup

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -281,6 +281,17 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "showInventoryClueTags",
+			name = "Show clue tags",
+			description = "Toggle whether to show details as item tags on all clues in your inventory",
+			position = 5
+	)
+	default boolean showInventoryClueTags()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 			keyName = "highlightFeather",
 			name = "Highlighted feathering",
 			description = "Configure the feathering of highlighted clues",

--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -27,18 +27,13 @@ package com.cluedetails;
 import com.cluedetails.filters.ClueOrders;
 import com.cluedetails.filters.ClueRegion;
 import com.cluedetails.filters.ClueTier;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.Notification;
-import net.runelite.client.util.Text;
+import net.runelite.client.config.*;
 
 @ConfigGroup("clue-details")
 public interface ClueDetailsConfig extends Config
@@ -184,18 +179,23 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "showSidebar",
-		name = "Show highlighting sidebar",
-		description = "Customise clues to be highlighted in a sidebar"
+		name = "Show sidebar",
+		description = "Customise clue details in a sidebar",
+		position = 1
 	)
 	default boolean showSidebar()
 	{
 		return true;
 	}
 
+	@ConfigSection(name = "Sidebar", description = "Options that effect the sidebar", position = 2, closedByDefault = true)
+	String sidebarSection = "Sidebar";
+
 	@ConfigItem(
 		keyName = "filterListByTier",
 		name = "Filter by tier",
 		description = "Configures what tier of clue to show",
+		section = sidebarSection,
 		position = 1
 	)
 	default ClueTierFilter filterListByTier()
@@ -207,6 +207,7 @@ public interface ClueDetailsConfig extends Config
 		keyName = "filterListByRegion",
 		name = "Filter by region",
 		description = "Configures what clues to show based on region they fall in",
+		section = sidebarSection,
 		position = 2
 	)
 	default ClueRegionFilter filterListByRegion()
@@ -218,6 +219,7 @@ public interface ClueDetailsConfig extends Config
 		keyName = "orderListBy",
 		name = "Clue sidebar order",
 		description = "Configures which way to order the clue list",
+		section = sidebarSection,
 		position = 3
 	)
 	default ClueOrdering orderListBy()
@@ -225,11 +227,15 @@ public interface ClueDetailsConfig extends Config
 		return ClueOrdering.TIER;
 	}
 
+	@ConfigSection(name = "Marked Clues", description = "Options that effect marked clues", position = 3, closedByDefault = false)
+	String markedCluesSection = "Marked Clues";
+
 	@ConfigItem(
 		keyName = "markedClueDroppedNotification",
 		name = "Notify when a marked clue drops",
 		description = "Send a notification when a marked clue drops",
-		position = 4
+		section = markedCluesSection,
+		position = 1
 	)
 	default Notification markedClueDroppedNotification()
 	{
@@ -240,7 +246,8 @@ public interface ClueDetailsConfig extends Config
 		keyName = "onlyShowMarkedClues",
 		name = "Only show marked clues in the sidebar",
 		description = "Toggle whether to only show marked clues in the sidebar",
-		position = 6
+		section = markedCluesSection,
+		position = 5
 	)
 	default boolean onlyShowMarkedClues()
 	{
@@ -251,7 +258,8 @@ public interface ClueDetailsConfig extends Config
 		keyName = "highlightMarkedClues",
 		name = "Highlight marked clues",
 		description = "Toggle whether to highlight marked clues",
-		position = 5
+		section = markedCluesSection,
+		position = 2
 	)
 	default boolean highlightMarkedClues()
 	{
@@ -259,43 +267,11 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "changeClueText",
-		name = "Change clue item text",
-		description = "Toggle whether to make the clue item text be the hint or the normal text",
-		position = 5
-	)
-	default boolean changeClueText()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "showInventoryCluesOverlay",
-		name = "Show clues overlay",
-		description = "Toggle whether to show an overlay with details on all clues in your inventory",
-		position = 5
-	)
-	default boolean showInventoryCluesOverlay()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-			keyName = "showInventoryClueTags",
-			name = "Show clue tags",
-			description = "Toggle whether to show details as item tags on all clues in your inventory",
-			position = 5
-	)
-	default boolean showInventoryClueTags()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-			keyName = "highlightFeather",
-			name = "Highlighted feathering",
-			description = "Configure the feathering of highlighted clues",
-			position = 5
+		keyName = "highlightFeather",
+		name = "Highlighted feathering",
+		description = "Configure the feathering of highlighted clues",
+	section = markedCluesSection,
+		position = 3
 	)
 	default int highlightFeather()
 	{
@@ -306,10 +282,50 @@ public interface ClueDetailsConfig extends Config
 			keyName = "outlineWidth",
 			name = "Highlighted outline width",
 			description = "Configure the outline width of highlighted clues",
-			position = 6
+			section = markedCluesSection,
+			position = 4
 	)
 	default int outlineWidth()
 	{
 		return 4;
+	}
+
+	@ConfigSection(name = "Overlays", description = "Options that effect overlays", position = 4, closedByDefault = false)
+	String overlaysSection = "Overlays";
+
+	@ConfigItem(
+		keyName = "showInventoryClueTags",
+		name = "Show clue tags",
+		description = "Toggle whether to show clue details as item tags",
+		section = overlaysSection,
+		position = 1
+	)
+	default boolean showInventoryClueTags()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showInventoryCluesOverlay",
+		name = "Show clues overlay",
+		description = "Toggle whether to show an overlay with details on all clues in your inventory",
+		section = overlaysSection,
+		position = 2
+	)
+	default boolean showInventoryCluesOverlay()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "changeClueText",
+		name = "Change clue item text",
+		description = "Toggle whether to make the clue item text be the hint or the normal text",
+		section = overlaysSection,
+		position = 3
+	)
+	default boolean changeClueText()
+	{
+		return false;
 	}
 }

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -69,6 +69,9 @@ public class ClueDetailsPlugin extends Plugin
 	private ClueDetailsOverlay infoOverlay;
 
 	@Inject
+	private ClueDetailsTagsOverlay tagsOverlay;
+
+	@Inject
 	private ClueDetailsWidgetOverlay widgetOverlay;
 
 	@Inject
@@ -100,6 +103,8 @@ public class ClueDetailsPlugin extends Plugin
 		overlayManager.add(infoOverlay);
 		eventBus.register(infoOverlay);
 
+		overlayManager.add(tagsOverlay);
+
 		overlayManager.add(widgetOverlay);
 		eventBus.register(widgetOverlay);
 
@@ -126,6 +131,8 @@ public class ClueDetailsPlugin extends Plugin
 	{
 		overlayManager.remove(infoOverlay);
 		eventBus.unregister(infoOverlay);
+
+		overlayManager.remove(tagsOverlay);
 
 		overlayManager.remove(widgetOverlay);
 		eventBus.unregister(widgetOverlay);

--- a/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
@@ -37,11 +37,13 @@ import net.runelite.client.ui.overlay.components.TextComponent;
 
 public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 {
+	private final ClueDetailsConfig config;
 	private final ConfigManager configManager;
 
 	@Inject
-	public ClueDetailsTagsOverlay(ConfigManager configManager)
+	public ClueDetailsTagsOverlay(ClueDetailsConfig config, ConfigManager configManager)
 	{
+		this.config = config;
 		this.configManager = configManager;
 		showOnInventory();
 		showOnBank();
@@ -51,7 +53,7 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem)
 	{
 		Clues clue = Clues.get(itemId);
-		if (clue != null)
+		if (config.showInventoryClueTags() && clue != null)
 		{
 			graphics.setFont(FontManager.getRunescapeSmallFont());
 			renderText(graphics, widgetItem.getCanvasBounds(), clue.getDisplayText(configManager));

--- a/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.cluedetails;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.util.Collection;
+import java.util.List;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.overlay.WidgetItemOverlay;
+import net.runelite.client.ui.overlay.components.TextComponent;
+
+public class ClueDetailsTagsOverlay extends WidgetItemOverlay
+{
+	private final ClueDetailsConfig config;
+	private final ConfigManager configManager;
+
+	static final Collection<Clues> clues = List.of(Clues.values());
+
+	@Inject
+	public ClueDetailsTagsOverlay(ClueDetailsConfig config, ConfigManager configManager)
+	{
+		this.config = config;
+		this.configManager = configManager;
+		showOnInventory();
+		showOnBank();
+	}
+
+	@Override
+	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem)
+	{
+		if (config.showInventoryClueTags()){
+			for (Clues clue : clues)
+			{
+				if (clue.getClueID() == itemId)
+				{
+					graphics.setFont(FontManager.getRunescapeSmallFont());
+					renderText(graphics, widgetItem.getCanvasBounds(), clue.getDisplayText(configManager));
+					break;
+				}
+			}
+		}
+	}
+
+	private void renderText(Graphics2D graphics, Rectangle bounds, String itemTag)
+	{
+		// Specific format due to backwards compatibility
+		String[] itemTags = itemTag.split(": ", 2);
+		final TextComponent textComponent = new TextComponent();
+		textComponent.setColor(Color.white);
+
+		int i = 0;
+		for (String tag : itemTags){
+			// Draw the text in the bottom left first, and top left second
+			textComponent.setPosition(new Point(bounds.x - 1, bounds.y - 1 + (i == 1
+					? bounds.height
+					: graphics.getFontMetrics().getHeight())));
+			textComponent.setText(tag);
+			textComponent.render(graphics);
+			i++;
+		}
+	}
+}

--- a/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Zoinkwiz <https://github.com/Zoinkwiz>
+ * Copyright (c) 2024, TheLope <https://github.com/TheLope>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,8 +29,6 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.util.Collection;
-import java.util.List;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.ui.FontManager;
@@ -39,15 +37,11 @@ import net.runelite.client.ui.overlay.components.TextComponent;
 
 public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 {
-	private final ClueDetailsConfig config;
 	private final ConfigManager configManager;
 
-	static final Collection<Clues> clues = List.of(Clues.values());
-
 	@Inject
-	public ClueDetailsTagsOverlay(ClueDetailsConfig config, ConfigManager configManager)
+	public ClueDetailsTagsOverlay(ConfigManager configManager)
 	{
-		this.config = config;
 		this.configManager = configManager;
 		showOnInventory();
 		showOnBank();
@@ -56,16 +50,11 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 	@Override
 	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem)
 	{
-		if (config.showInventoryClueTags()){
-			for (Clues clue : clues)
-			{
-				if (clue.getClueID() == itemId)
-				{
-					graphics.setFont(FontManager.getRunescapeSmallFont());
-					renderText(graphics, widgetItem.getCanvasBounds(), clue.getDisplayText(configManager));
-					break;
-				}
-			}
+		Clues clue = Clues.get(itemId);
+		if (clue != null)
+		{
+			graphics.setFont(FontManager.getRunescapeSmallFont());
+			renderText(graphics, widgetItem.getCanvasBounds(), clue.getDisplayText(configManager));
 		}
 	}
 

--- a/src/main/java/com/cluedetails/panels/ClueSelectLabel.java
+++ b/src/main/java/com/cluedetails/panels/ClueSelectLabel.java
@@ -125,7 +125,7 @@ public class ClueSelectLabel extends JLabel
 			@Override
 			public void actionPerformed(ActionEvent event)
 			{
-				chatboxPanelManager.openTextInput("Enter new clue name:")
+				chatboxPanelManager.openTextInput("Enter new clue text:")
 					.onDone((newTag) -> {
 						configManager.setConfiguration("clue-details-text", String.valueOf(clue.getClueID()), newTag);
 						setText(generateText(clue.getDisplayText(configManager)));


### PR DESCRIPTION
- Currently when the toggle is enabled, clue-details-text is automatically split based on the first ": ". This is to ensure compatibility with the old style of custom item tags, however this could be modified or made configurable.
- Currently the item tags are automatically rendered at the top of the clue if no split is applied