### PR TITLE
bugfix: ensure right click text replace only applies to Take

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -165,7 +165,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 				{
 					MenuEntry hoveredEntry = currentMenuEntries[i];
 					Clues clue = Clues.get(hoveredEntry.getIdentifier());
-					if (clue != null)
+					if (clue != null && isTakeClue(hoveredEntry))
 					{
 						hoveredEntry.setTarget("<col=ff9146>" + clue.getDisplayText(configManager) + "<col=FFA07A>");
 					}


### PR DESCRIPTION
Could do something less restrictive than only replacing Take text, but imo this makes shift right click menu less confusing when considering interacting with other plugins.
 
Before:
![image](https://github.com/user-attachments/assets/faffc4c4-ca4b-43a2-9d46-c41f6bf098b4)
![image](https://github.com/user-attachments/assets/7fb47ea1-2bc3-4349-b62a-91d9089c16c4)

After:
![image](https://github.com/user-attachments/assets/9a5f9a59-f288-44b4-b7b4-0c72a7324e17)
![image](https://github.com/user-attachments/assets/6734d72b-e968-45f1-8767-4a8b394c5926)
