### PR TITLE
fix: Fake beginner & master IDs outlined incorrectly

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -345,6 +345,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 
 	private boolean shouldHighlight(int id)
 	{
+		if (id < 2677) return false; //TODO: Support fake beginner & master IDs
 		String shouldHighlight = configManager.getConfiguration("clue-details-highlights", String.valueOf(id));
 		return "true".equals(shouldHighlight);
 	}
@@ -518,6 +519,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 				return;
 			}
 
+			// TODO: Currently outlines all items in the tile
 			modelOutlineRenderer.drawOutline(
 				tile.getItemLayer(),
 				config.outlineWidth(),


### PR DESCRIPTION
- Items which share an id with the fake beginner & master clue IDs are being highlighted when those clues are marked
  - Fire rune: ![image](https://github.com/user-attachments/assets/19668db0-88eb-457d-8604-d6095f7b26b8)
- Beginner & Master Clues are not able to be properly marked - TODO added
- Outlining marked clues also outlines other items in the same tile - TODO added
  - Coins: ![image](https://i.imgur.com/JZyZCBc.gif)