### PR TITLE
2.1.1: Separate text and colors export; fix beginner/master colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ The "Show clue tags" toggle in the plugin's settings renders the details on the 
 
 ![365446878-169c15ad-f793-4c7d-af0c-a2b787f072f0](https://github.com/user-attachments/assets/cac24b71-74a8-4a13-94b7-6d61ae5d1813)
 
-The "Show clues overlay" toggle in the plugin's settings renders the details as an infobox for all clues in your inventory.
+The "Show inventory overlay" toggle in the plugin's settings renders the details as an infobox for all clues in your inventory.
 
 ![365445046-c5c40aa4-b2d1-46a4-aa31-9ce609760bb6](https://github.com/user-attachments/assets/a1386cd7-7802-471f-92cd-9578688bda83)
 
-The "Change clue item text" toggle in the plugin's settings makes it so the actual text of the clue item is adjusted, so you don't even need to hover for details.
+The "Change ground menu text" toggle in the plugin's settings adjusts the actual text of the clue item menu text, so you don't even need to hover for details.
 
 ![Screenshot 2024-09-01 221305](https://github.com/user-attachments/assets/72685ba5-f441-4cac-b18c-6cc0ddf42d98)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Updating Ground Items and Inventory Tags colors is also supported.
 
 - Enable the configuration options in the "Overlay Colors" section prior to editing colors. This is applied at the time the colors are edited/imported.
   
-- ![Ody99cS](https://github.com/user-attachments/assets/59060f5d-2b43-484f-b593-4079abc7996e)
+- ![zqZvd7j](https://github.com/user-attachments/assets/b5f9db3e-d2fb-4f3e-95f5-2197feadd591)
 
 - Resetting Ground Items and Inventory Tags colors must be done via those plugins.
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.example'
-version = '2.1.0'
+version = '2.1.1'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -186,7 +186,9 @@ public interface ClueDetailsConfig extends Config
 		TOP(false, "Top"),
 		BOTTOM(false, "Bottom");
 
-		ClueTagLocation(Object selected, String displayName) {}
+		ClueTagLocation(Object selected, String displayName)
+		{
+		}
 	}
 
 	@ConfigItem(
@@ -355,7 +357,7 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "showInventoryCluesOverlay",
-		name = "Show details overlay",
+		name = "Show inventory overlay",
 		description = "Toggle whether to show an overlay with details of all clues in your inventory",
 		section = overlaysSection,
 		position = 4
@@ -405,25 +407,25 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "colorChangeClueText",
-		name = "Color ground menu text",
-		description = "Toggle whether to apply clue details color to ground menu text",
+		keyName = "colorInventoryCluesOverlay",
+		name = "Color inventory overlay",
+		description = "Toggle whether to apply clue details color to inventory overlay",
 		section = overlayColorsSection,
 		position = 2
 	)
-	default boolean colorChangeClueText()
+	default boolean colorInventoryCluesOverlay()
 	{
 		return true;
 	}
 
 	@ConfigItem(
-		keyName = "colorInventoryCluesOverlay",
-		name = "Color details overlay",
-		description = "Toggle whether to apply clue details color to details overlay",
+		keyName = "colorChangeClueText",
+		name = "Color ground menu text",
+		description = "Toggle whether to apply clue details color to ground menu text",
 		section = overlayColorsSection,
 		position = 3
 	)
-	default boolean colorInventoryCluesOverlay()
+	default boolean colorChangeClueText()
 	{
 		return true;
 	}

--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -291,11 +291,11 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "outlineWidth",
-			name = "Highlighted outline width",
-			description = "Configure the outline width of highlighted clues",
-			section = markedCluesSection,
-			position = 4
+		keyName = "outlineWidth",
+		name = "Highlighted outline width",
+		description = "Configure the outline width of highlighted clues",
+		section = markedCluesSection,
+		position = 4
 	)
 	default int outlineWidth()
 	{
@@ -308,7 +308,7 @@ public interface ClueDetailsConfig extends Config
 	@ConfigItem(
 		keyName = "showHoverText",
 		name = "Show hover text",
-		description = "Toggle whether to hide tooltips on clue hover",
+		description = "Toggle whether to show tooltips on clue hover",
 		section = overlaysSection,
 		position = 0
 	)
@@ -342,11 +342,11 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "clueTagSplit",
-			name = "Clue tag split sequence",
-			description = "Character sequence on which the tag will be split",
-			section = overlaysSection,
-			position = 3
+		keyName = "clueTagSplit",
+		name = "Clue tag split sequence",
+		description = "Character sequence on which the tag will be split",
+		section = overlaysSection,
+		position = 3
 	)
 	default String clueTagSplit()
 	{
@@ -355,8 +355,8 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "showInventoryCluesOverlay",
-		name = "Show clues overlay",
-		description = "Toggle whether to show an overlay with details on all clues in your inventory",
+		name = "Show details overlay",
+		description = "Toggle whether to show an overlay with details of all clues in your inventory",
 		section = overlaysSection,
 		position = 4
 	)
@@ -367,8 +367,8 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "changeClueText",
-		name = "Change clue item text",
-		description = "Toggle whether to make the clue item text be the hint or the normal text",
+		name = "Change ground menu text",
+		description = "Toggle whether to make the ground menu text be the clue detail",
 		section = overlaysSection,
 		position = 5
 	)
@@ -383,7 +383,7 @@ public interface ClueDetailsConfig extends Config
 	@ConfigItem(
 		keyName = "colorHoverText",
 		name = "Color hover text",
-		description = "Toggle whether apply clue details color to hover text",
+		description = "Toggle whether to apply clue details color to hover text",
 		section = overlayColorsSection,
 		position = 0
 	)
@@ -395,7 +395,7 @@ public interface ClueDetailsConfig extends Config
 	@ConfigItem(
 		keyName = "colorInventoryClueTags",
 		name = "Color clue tags",
-		description = "Toggle whether apply clue details color to clue tags",
+		description = "Toggle whether to apply clue details color to clue tags",
 		section = overlayColorsSection,
 		position = 1
 	)
@@ -406,8 +406,8 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "colorChangeClueText",
-		name = "Color clue item text",
-		description = "Toggle whether apply clue details color to clue item text",
+		name = "Color ground menu text",
+		description = "Toggle whether to apply clue details color to ground menu text",
 		section = overlayColorsSection,
 		position = 2
 	)
@@ -418,8 +418,8 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "colorInventoryCluesOverlay",
-		name = "Color clues overlay",
-		description = "Toggle whether apply clue details color to clues overlay",
+		name = "Color details overlay",
+		description = "Toggle whether to apply clue details color to details overlay",
 		section = overlayColorsSection,
 		position = 3
 	)
@@ -430,8 +430,9 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "colorGroundItems",
-		name = "Apply colors to Ground Items",
-		description = "When updating clue details colors, apply the color to the Ground Items plugin. Does not supprt beginner and master clues",
+		name = "Overwrite Ground Items colors",
+		description = "When updating clue details colors, apply the color to the Ground Items plugin",
+		warning = "Does not work for Beginner and Master clues. Colors must be reset via Ground Items plugin.",
 		section = overlayColorsSection,
 		position = 4
 	)
@@ -442,8 +443,9 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "colorInventoryTags",
-		name = "Apply colors to Inventory Tags",
-		description = "When updating clue details colors, apply the color to the Inventory Tags plugin. Does not supprt beginner and master clues",
+		name = "Overwrite Inventory Tags colors",
+		description = "When updating clue details colors, apply the color to the Inventory Tags plugin",
+		warning = "Does not work for Beginner and Master clues. Colors must be reset via Inventory Tags plugin.",
 		section = overlayColorsSection,
 		position = 5
 	)

--- a/src/main/java/com/cluedetails/ClueDetailsSharingManager.java
+++ b/src/main/java/com/cluedetails/ClueDetailsSharingManager.java
@@ -88,7 +88,7 @@ public class ClueDetailsSharingManager
 		}
 	}
 
-	public void exportClueDetails()
+	public void exportClueDetails(boolean exportText, boolean exportColors)
 	{
 		List<ClueIdToDetails> clueIdToDetailsList = new ArrayList<>();
 
@@ -103,24 +103,33 @@ public class ClueDetailsSharingManager
 			String clueText = configManager.getConfiguration("clue-details-text", String.valueOf(id));
 			String clueColor = configManager.getConfiguration("clue-details-color", String.valueOf(id));
 
-			// Support importing text, or color, or both
-			if (clueColor != null)
+			if (exportText && exportColors)
 			{
-				if (clueText != null)
+				// Export both
+				if (clueText != null && clueColor != null)
 				{
 					clueIdToDetailsList.add(new ClueIdToDetails(id, clueText, Color.decode(clueColor)));
 				}
-				else
+				// Export text
+				else if (clueText != null)
+				{
+					clueIdToDetailsList.add(new ClueIdToDetails(id, clueText));
+				}
+				// Export colors
+				else if (clueColor != null)
 				{
 					clueIdToDetailsList.add(new ClueIdToDetails(id, Color.decode(clueColor)));
 				}
 			}
-			else
+			// Export text
+			else if (exportText && clueText != null)
 			{
-				if (clueText != null)
-				{
-					clueIdToDetailsList.add(new ClueIdToDetails(id, clueText));
-				}
+				clueIdToDetailsList.add(new ClueIdToDetails(id, clueText));
+			}
+			// Export colors
+			else if (exportColors && clueColor != null)
+			{
+				clueIdToDetailsList.add(new ClueIdToDetails(id, Color.decode(clueColor)));
 			}
 		}
 

--- a/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
@@ -105,7 +105,7 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 					if (threeStepCrypticClue != null)
 					{
 						threeStepCrypticClue.update(clueDetailsPlugin.getClueInventoryManager().getTrackedCluesInInventory());
-						clueDetail = threeStepCrypticClue.getDetail(configManager);
+						clueDetail = threeStepCrypticClue.getDetail(configManager, config);
 						clueDetailColor = Color.WHITE;
 					}
 					else
@@ -151,11 +151,6 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 
 		final TextComponent textComponent = new TextComponent();
 
-		if (config.colorInventoryClueTags())
-		{
-			textComponent.setColor(clueDetailColor);
-		}
-
 		String[] clueDetails = new String [] {clueDetail};
 		// Handle Three Step Cryptic Clues
 		if (clueDetail.contains("<br>"))
@@ -168,9 +163,21 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 			&& !config.clueTagSplit().isEmpty()
 			&& clueDetails.length == 1)
 		{
+			// Correct clueDetailColor for three step cryptic clue
+			if (clueDetail.contains("<col="))
+			{
+				clueDetailColor = Color.decode("#" + getStringBetween(clueDetail, "<col=", ">"));
+			}
+
 			clueDetails = clueDetails[0].split(config.clueTagSplit(), 3);
 		}
 
+		if (config.colorInventoryClueTags())
+		{
+			textComponent.setColor(clueDetailColor);
+		}
+
+		// Render tag in configured location
 		int i = 0;
 		int detailCount = clueDetails.length;
 		for (String detail : clueDetails)
@@ -183,5 +190,21 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 			textComponent.render(graphics);
 			i++;
 		}
+	}
+
+	public static String getStringBetween(String input, String start, String end) {
+		int startIndex = input.indexOf(start);
+		if (startIndex == -1) {
+			return null; // Start string not found
+		}
+
+		startIndex += start.length(); // Move past the start string
+
+		int endIndex = input.indexOf(end, startIndex);
+		if (endIndex == -1) {
+			return null; // End string not found
+		}
+
+		return input.substring(startIndex, endIndex);
 	}
 }

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -24,6 +24,7 @@
  */
 package com.cluedetails;
 
+import java.awt.Color;
 import java.util.List;
 import lombok.Data;
 import lombok.Getter;
@@ -95,7 +96,7 @@ public class ClueInstance
 		return timeToDespawnFromDataInTicks == null ? -1 : timeToDespawnFromDataInTicks;
 	}
 
-	public String getCombinedClueText(ConfigManager configManager, boolean showColor)
+	public String getCombinedClueText(ConfigManager configManager, boolean showColor, boolean isFloorText)
 	{
 		StringBuilder returnText = new StringBuilder();
 		boolean isFirst = true;
@@ -114,8 +115,14 @@ public class ClueInstance
 
 			if (showColor)
 			{
-				String color = Integer.toHexString(cluePart.getDetailColor(configManager).getRGB()).substring(2);
-				returnText.append("<col=").append(color).append(">");
+				Color color = cluePart.getDetailColor(configManager);
+
+				// Only change floor text color if it's not the default
+				if (!(isFloorText && color == Color.WHITE))
+				{
+					String hexColor = Integer.toHexString(color.getRGB()).substring(2);
+					returnText.append("<col=").append(hexColor).append(">");
+				}
 			}
 
 			returnText.append(cluePart.getDetail(configManager));

--- a/src/main/java/com/cluedetails/ThreeStepCrypticClue.java
+++ b/src/main/java/com/cluedetails/ThreeStepCrypticClue.java
@@ -95,7 +95,7 @@ public class ThreeStepCrypticClue
 		}
 	}
 
-	public String getDetail(ConfigManager configManager)
+	public String getDetail(ConfigManager configManager, ClueDetailsConfig config)
 	{
 		StringBuilder text = new StringBuilder();
 
@@ -105,8 +105,12 @@ public class ThreeStepCrypticClue
 			{
 				Clues clue = e.getKey();
 				String detail = clue.getDetail(configManager);
-				String color = Integer.toHexString(clue.getDetailColor(configManager).getRGB()).substring(2);
-				text.append("<col=").append(color).append(">").append(detail).append("<br>");
+				if (config.colorInventoryClueTags())
+				{
+					String color = Integer.toHexString(clue.getDetailColor(configManager).getRGB()).substring(2);
+					text.append("<col=").append(color).append(">");
+				}
+				text.append(detail).append("<br>");
 			}
 		}
 		return text.toString();

--- a/src/main/java/com/cluedetails/panels/ClueDetailsParentPanel.java
+++ b/src/main/java/com/cluedetails/panels/ClueDetailsParentPanel.java
@@ -27,7 +27,6 @@ package com.cluedetails.panels;
 import com.cluedetails.*;
 import com.cluedetails.ClueDetailsConfig.*;
 
-import com.google.gson.Gson;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -400,7 +399,14 @@ public class ClueDetailsParentPanel extends PluginPanel
 			@Override
 			public void mousePressed(MouseEvent e)
 			{
-				clueDetailsSharingManager.exportClueDetails();
+				if (e.getButton() == MouseEvent.BUTTON1)
+				{
+					clueDetailsSharingManager.exportClueDetails(true, true);
+				}
+				else if (e.getButton() == MouseEvent.BUTTON3)
+				{
+					selectiveExport(e);
+				}
 			}
 
 			@Override
@@ -466,6 +472,25 @@ public class ClueDetailsParentPanel extends PluginPanel
 		allDropdownSections.add(orderPanel);
 
 		searchCluesPanel.add(allDropdownSections, BorderLayout.NORTH);
+	}
+
+	private void selectiveExport(MouseEvent e)
+	{
+		JPopupMenu popupMenu = new JPopupMenu();
+
+		JMenuItem inputItemExportText = new JMenuItem("Export clue text");
+		inputItemExportText.addActionListener(event
+			-> clueDetailsSharingManager.exportClueDetails(true, false
+		));
+		popupMenu.add(inputItemExportText);
+
+		JMenuItem inputItemExportColors = new JMenuItem("Export clue colors");
+		inputItemExportColors.addActionListener(event
+			-> clueDetailsSharingManager.exportClueDetails(false, true
+		));
+		popupMenu.add(inputItemExportColors);
+
+		popupMenu.show(e.getComponent(), e.getX(), e.getY());
 	}
 
 	private JComboBox<Enum> makeNewDropdown(Enum[] values, String key)


### PR DESCRIPTION
Added extra right click options to export button to provide separate text and colors export
![image](https://github.com/user-attachments/assets/5434491f-2488-49da-b79b-5fcf5411bd1c)

Beginner/Master right click text was incorrectly recolored w/ default value
![image](https://github.com/user-attachments/assets/2d95a6c3-92eb-4da2-962c-b86cb27f4400)
Now correctly shows normal color if not changed by user
![image](https://github.com/user-attachments/assets/e3688918-eb81-48b5-a87f-98c81e7106a1)

Cleaned up Config settings with more clear descriptions and warnings
