### PR TITLE
Ground Clues Overlay for Beginner & Master Clues

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,17 @@ The "Show clue tags" toggle in the plugin's settings renders the details on the 
 
 ![365446878-169c15ad-f793-4c7d-af0c-a2b787f072f0](https://github.com/user-attachments/assets/cac24b71-74a8-4a13-94b7-6d61ae5d1813)
 
-The "Show clues overlay" toggle in the plugin's settings renders the details as an infobox for all clues in your inventory.
+The "Show inventory overlay" toggle in the plugin's settings renders the details as an infobox for all clues in your inventory.
 
 ![365445046-c5c40aa4-b2d1-46a4-aa31-9ce609760bb6](https://github.com/user-attachments/assets/a1386cd7-7802-471f-92cd-9578688bda83)
 
-The "Change clue item text" toggle in the plugin's settings makes it so the actual text of the clue item is adjusted, so you don't even need to hover for details.
+The "Change ground clue text" toggle in the plugin's settings makes it so the actual text of the clue item is adjusted, so you don't even need to hover for details.
 
 ![Screenshot 2024-09-01 221305](https://github.com/user-attachments/assets/72685ba5-f441-4cac-b18c-6cc0ddf42d98)
+
+The "Show ground clues" toggle shows text overlay for Beginner and Master ground clues, similar to the Ground Items plugin.
+
+![ground_clues](https://github.com/user-attachments/assets/bb067da3-faaf-4d5f-a521-d1c3b030ab9b)
 
 ## Editing clue details
 
@@ -60,11 +64,8 @@ Colors will now be updated for the specific clue depending on the configuration 
 
 Updating Ground Items and Inventory Tags colors is also supported. 
 
-- Enable the configuration options in the "Overlay Colors" section prior to editing colors. This is applied at the time the colors are edited/imported.
-  
-- ![Ody99cS](https://github.com/user-attachments/assets/59060f5d-2b43-484f-b593-4079abc7996e)
-
-- Resetting Ground Items and Inventory Tags colors must be done via those plugins.
+- Enable the "Overwrite ..." configuration options in the "Overlay Colors" section prior to editing colors. This is applied at the time the colors are edited/imported.
+    - Resetting Ground Items and Inventory Tags colors must be done via those plugins.
 
 ## Import/Export clue details
 

--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -186,7 +186,9 @@ public interface ClueDetailsConfig extends Config
 		TOP(false, "Top"),
 		BOTTOM(false, "Bottom");
 
-		ClueTagLocation(Object selected, String displayName) {}
+		ClueTagLocation(Object selected, String displayName)
+		{
+		}
 	}
 
 	@ConfigItem(
@@ -291,11 +293,11 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "outlineWidth",
-			name = "Highlighted outline width",
-			description = "Configure the outline width of highlighted clues",
-			section = markedCluesSection,
-			position = 4
+		keyName = "outlineWidth",
+		name = "Highlighted outline width",
+		description = "Configure the outline width of highlighted clues",
+		section = markedCluesSection,
+		position = 4
 	)
 	default int outlineWidth()
 	{
@@ -308,7 +310,7 @@ public interface ClueDetailsConfig extends Config
 	@ConfigItem(
 		keyName = "showHoverText",
 		name = "Show hover text",
-		description = "Toggle whether to hide tooltips on clue hover",
+		description = "Toggle whether to show tooltips on clue hover",
 		section = overlaysSection,
 		position = 0
 	)
@@ -342,11 +344,11 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "clueTagSplit",
-			name = "Clue tag split sequence",
-			description = "Character sequence on which the tag will be split",
-			section = overlaysSection,
-			position = 3
+		keyName = "clueTagSplit",
+		name = "Clue tag split sequence",
+		description = "Character sequence on which the tag will be split",
+		section = overlaysSection,
+		position = 3
 	)
 	default String clueTagSplit()
 	{
@@ -355,7 +357,7 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "showInventoryCluesOverlay",
-		name = "Show clues overlay",
+		name = "Show inventory overlay",
 		description = "Toggle whether to show an overlay with details on all clues in your inventory",
 		section = overlaysSection,
 		position = 4
@@ -367,8 +369,8 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "changeClueText",
-		name = "Change clue item text",
-		description = "Toggle whether to make the clue item text be the hint or the normal text",
+		name = "Change ground item menu text",
+		description = "Toggle whether to change the ground item menu text to the clue detail",
 		section = overlaysSection,
 		position = 5
 	)
@@ -383,7 +385,7 @@ public interface ClueDetailsConfig extends Config
 	@ConfigItem(
 		keyName = "colorHoverText",
 		name = "Color hover text",
-		description = "Toggle whether apply clue details color to hover text",
+		description = "Toggle whether to apply clue details color to hover text",
 		section = overlayColorsSection,
 		position = 0
 	)
@@ -395,7 +397,7 @@ public interface ClueDetailsConfig extends Config
 	@ConfigItem(
 		keyName = "colorInventoryClueTags",
 		name = "Color clue tags",
-		description = "Toggle whether apply clue details color to clue tags",
+		description = "Toggle whether to apply clue details color to clue tags",
 		section = overlayColorsSection,
 		position = 1
 	)
@@ -405,23 +407,11 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "colorChangeClueText",
-		name = "Color clue item text",
-		description = "Toggle whether apply clue details color to clue item text",
+		keyName = "colorInventoryCluesOverlay",
+		name = "Color inventory overlay",
+		description = "Toggle whether to apply clue details color to clues overlay",
 		section = overlayColorsSection,
 		position = 2
-	)
-	default boolean colorChangeClueText()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "colorInventoryCluesOverlay",
-		name = "Color clues overlay",
-		description = "Toggle whether apply clue details color to clues overlay",
-		section = overlayColorsSection,
-		position = 3
 	)
 	default boolean colorInventoryCluesOverlay()
 	{
@@ -429,9 +419,22 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "colorChangeClueText",
+		name = "Color ground item menu text",
+		description = "Toggle whether to apply clue details color to ground item menu text",
+		section = overlayColorsSection,
+		position = 3
+	)
+	default boolean colorChangeClueText()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "colorGroundItems",
-		name = "Apply colors to Ground Items",
-		description = "When updating clue details colors, apply the color to the Ground Items plugin. Does not supprt beginner and master clues",
+		name = "Overwrite Ground Items colors",
+		description = "When updating clue details colors, apply the color to the Ground Items plugin",
+		warning = "Does not work for Beginner and Master clues. Colors must be reset via Ground Items plugin.",
 		section = overlayColorsSection,
 		position = 4
 	)
@@ -442,13 +445,77 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "colorInventoryTags",
-		name = "Apply colors to Inventory Tags",
-		description = "When updating clue details colors, apply the color to the Inventory Tags plugin. Does not supprt beginner and master clues",
+		name = "Overwrite Inventory Tags colors",
+		description = "When updating clue details colors, apply the color to the Inventory Tags plugin",
+		warning = "Does not work for Beginner and Master clues. Colors must be reset via Inventory Tags plugin.",
 		section = overlayColorsSection,
 		position = 5
 	)
 	default boolean colorInventoryTags()
 	{
 		return false;
+	}
+
+	@ConfigSection(name = "Ground Clues", description = "Options that effect ground clues overlay (only supports Beginner and Master clues", position = 6)
+	String groundCluesSection = "Ground Clues";
+
+	@ConfigItem(
+		keyName = "showGroundClues",
+		name = "Show ground clues",
+		description = "Toggle whether to show ground clues overlay",
+		section = groundCluesSection,
+		position = 0
+	)
+	default boolean showGroundClues()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "changeGroundClueText",
+		name = "Change ground clue text",
+		description = "Toggle whether to change the ground clue text to the clue detail",
+		section = groundCluesSection,
+		position = 1
+	)
+	default boolean changeGroundClueText()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showGroundCluesDespawn",
+		name = "Show ground clues despawn",
+		description = "Toggle whether to add despawn timers to the ground clues overlay",
+		section = groundCluesSection,
+		position = 2
+	)
+	default boolean showGroundCluesDespawn()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "collapseGroundClues",
+		name = "Collapse ground clues",
+		description = "Toggle whether to combine duplicates in the ground clues overlay",
+		section = groundCluesSection,
+		position = 3
+	)
+	default boolean collapseGroundClues()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "colorGroundClues",
+		name = "Color ground clues",
+		description = "Toggle whether to apply clue details color to ground clue text",
+		section = groundCluesSection,
+		position = 4
+	)
+	default boolean colorGroundClues()
+	{
+		return true;
 	}
 }

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -552,7 +552,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 		// Ignore three-step cryptic clues
 		if (clueInstance != null && clueInstance.getClueIds().size() == 1)
 		{
-			Clues cluePart = Clues.forClueId(clueInstance.getClueIds().get(0));
+			Clues cluePart = Clues.forClueIdFiltered(clueInstance.getClueIds().get(0));
 			if (cluePart != null)
 			{
 				return Integer.toHexString(cluePart.getDetailColor(configManager).getRGB()).substring(2);

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -50,6 +50,7 @@ import net.runelite.api.Tile;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemDespawned;
 import net.runelite.api.events.ItemSpawned;
@@ -65,6 +66,7 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
+import net.runelite.client.util.Text;
 
 public class ClueDetailsOverlay extends OverlayPanel
 {
@@ -158,6 +160,11 @@ public class ClueDetailsOverlay extends OverlayPanel
 			return;
 		}
 
+		if (isTakeClue(menuEntry) && config.changeClueText())
+		{
+			return;
+		}
+
 		String clueText = getText(menuEntryAndPos, config.colorHoverText());
 
 		if (clueText == null) return;
@@ -187,6 +194,24 @@ public class ClueDetailsOverlay extends OverlayPanel
 		}
 	}
 
+	// Using onClientTick for compatability with Ground Items "Collapse ground item menu"
+	@Subscribe
+	public void onClientTick(ClientTick event)
+	{
+		final MenuEntry[] menuEntries = client.getMenuEntries();
+		if (Arrays.stream(menuEntries).noneMatch(this::isTakeClue))
+		{
+			return;
+		}
+
+		List<MenuEntryAndPos> entriesByTile = getEntriesByTile(menuEntries);
+
+		if (config.changeClueText() || config.colorChangeClueText())
+		{
+			changeGroundItemMenu(entriesByTile);
+		}
+	}
+
 	@Subscribe
 	public void onMenuOpened(MenuOpened event)
 	{
@@ -200,50 +225,67 @@ public class ClueDetailsOverlay extends OverlayPanel
 
 		if (config.changeClueText())
 		{
-			changeFloorText(entriesByTile);
+			addClueSubmenus(entriesByTile);
 		}
 	}
 
-	private void changeFloorText(List<MenuEntryAndPos> entriesByTile)
+	private void changeGroundItemMenu(List<MenuEntryAndPos> entriesByTile)
 	{
-		// Change text of actual clue
+		// Change ground item menu text
 		for (MenuEntryAndPos entryAndPos : entriesByTile)
 		{
 			MenuEntry menuEntry = entryAndPos.getMenuEntry();
+			if (!isTakeOrMarkClue(menuEntry)) continue;
 
-			boolean showColor = config.colorChangeClueText();
-			// Only change color if it is not the default
-			if (showColor)
-			{
-				int scrollID = menuEntry.getIdentifier();
-				if (isReadClue(menuEntry))
-				{
-					scrollID = menuEntry.getItemId();
-				}
-				Clues matchingClue = Clues.forItemId(scrollID);
-
-				if (matchingClue != null)
-				{
-					if (matchingClue.getDetailColor(configManager) == Color.WHITE)
-					{
-						showColor = false;
-					}
-				}
-			}
-
-			String newText = getText(entryAndPos, showColor);
-			if (newText == null || !isTakeOrMarkClue(menuEntry)) continue;
-			String regex = "Clue scroll \\(.*?\\)";
+			boolean showColor = shouldShowColor(menuEntry);
+			String regex = "(Clue scroll \\(.*?\\)|Challenge scroll \\(.*?\\))";
 			if (clueDetailsPlugin.isDeveloperMode())
 			{
-				regex = "(Daeyalt essence|Clue scroll \\(.*?\\))";
+				regex = "(Daeyalt essence|Clue scroll \\(.*?\\)|Challenge scroll \\(.*?\\))";
 			}
 
 			// Compile the pattern
 			Pattern pattern = Pattern.compile(regex);
 			Matcher matcher = pattern.matcher(menuEntry.getTarget());
 
+			String newText;
+			// Change ground item menu text & color
+			if (config.changeClueText())
+			{
+				newText = getText(entryAndPos, showColor);
+			}
+			// Change ground item menu color
+			else
+			{
+				newText = recolorText(entryAndPos);
+			}
+
+			if (newText == null) continue;
+
 			// Handle master three-step cryptic
+			if (newText.split("<br>").length > 1)
+			{
+				newText = "Three-step (master)";
+			}
+			// Replace the matched text with the new text
+			String newTarget = matcher.replaceAll(newText);
+
+			menuEntry.setTarget(newTarget);
+		}
+	}
+
+	private void addClueSubmenus(List<MenuEntryAndPos> entriesByTile)
+	{
+		// Add submenus to three-step cryptic clues
+		for (MenuEntryAndPos entryAndPos : entriesByTile)
+		{
+			MenuEntry menuEntry = entryAndPos.getMenuEntry();
+
+			boolean showColor = shouldShowColor(menuEntry);
+
+			String newText = getText(entryAndPos, showColor);
+			if (newText == null || !isTakeOrMarkClue(menuEntry)) continue;
+
 			String[] newTexts = newText.split("<br>");
 
 			// TODO: Text doesn't update after details changed
@@ -258,13 +300,28 @@ public class ClueDetailsOverlay extends OverlayPanel
 						.setOption(text)
 						.setType(MenuAction.RUNELITE);
 				}
-				newText = "Three-step (master)";
 			}
-			// Replace the matched text with the new text
-			String newTarget = matcher.replaceAll(newText);
-
-			menuEntry.setTarget(newTarget);
 		}
+	}
+
+	private boolean shouldShowColor(MenuEntry menuEntry)
+	{
+		// Only change color if it is not the default
+		boolean showColor = config.colorChangeClueText();
+		if (showColor)
+		{
+			int scrollID = getScrollID(menuEntry);
+			Clues matchingClue = Clues.forItemId(scrollID);
+
+			if (matchingClue != null)
+			{
+				if (matchingClue.getDetailColor(configManager) == Color.WHITE)
+				{
+					showColor = false;
+				}
+			}
+		}
+		return showColor;
 	}
 
 	private void addTooltip(List<MenuEntryAndPos> relevantMenuEntries)
@@ -294,7 +351,15 @@ public class ClueDetailsOverlay extends OverlayPanel
 
 		String text = getText(entryAndPos, config.colorHoverText());
 
-		panelComponent.getChildren().add(LineComponent.builder().left(text).build());
+		// Handle master three-step cryptic
+		if (text != null)
+		{
+			for (String splitText : text.split("<br>"))
+			{
+				panelComponent.getChildren().add(LineComponent.builder().left(splitText).build());
+			}
+		}
+
 		double infoPanelWidth = panelComponent.getBounds().getWidth();
 		int viewportWidth = client.getViewportWidth();
 		if (menuX + menuWidth + infoPanelWidth > viewportWidth)
@@ -372,21 +437,39 @@ public class ClueDetailsOverlay extends OverlayPanel
 		return "true".equals(shouldHighlight);
 	}
 
-	private String getText(MenuEntryAndPos menuEntryAndPos, boolean showColor)
+	private int getScrollID(MenuEntry menuEntry)
 	{
-		MenuEntry menuEntry = menuEntryAndPos.getMenuEntry();
 		int scrollID = menuEntry.getIdentifier();
 		if (isReadClue(menuEntry))
 		{
 			scrollID = menuEntry.getItemId();
 		}
+		return scrollID;
+	}
+
+	private boolean areEntriesInTile(MenuEntry menuEntry)
+	{
+		MenuEntry[] currentMenuEntries = {menuEntry};
+		if (Arrays.stream(currentMenuEntries).anyMatch(this::isTakeClue))
+		{
+			List<MenuEntryAndPos> entriesByTile = getEntriesByTile(currentMenuEntries);
+			return !entriesByTile.isEmpty();
+		}
+		return false;
+	}
+
+	private String getText(MenuEntryAndPos menuEntryAndPos, boolean showColor)
+	{
+		MenuEntry menuEntry = menuEntryAndPos.getMenuEntry();
+		int scrollID = getScrollID(menuEntry);
+
 		Clues matchingClue = Clues.forItemId(scrollID);
 		if (matchingClue != null)
 		{
 			String text = matchingClue.getDetail(configManager);
-			String color = Integer.toHexString(matchingClue.getDetailColor(configManager).getRGB()).substring(2);
 			if (showColor)
 			{
+				String color = Integer.toHexString(matchingClue.getDetailColor(configManager).getRGB()).substring(2);
 				return "<col=" + color + ">" + text;
 			}
 			return text;
@@ -397,26 +480,44 @@ public class ClueDetailsOverlay extends OverlayPanel
 			ClueInstance clueInstance = clueInventoryManager.getTrackedClueByClueItemId(scrollID);
 			if (clueInstance != null && !clueInstance.getClueIds().isEmpty())
 			{
-				return clueInstance.getCombinedClueText(configManager, showColor);
+				return clueInstance.getCombinedClueText(clueDetailsPlugin, configManager, showColor);
 			}
 		}
 
-		MenuEntry[] currentMenuEntries = {menuEntry};
-		List<MenuEntryAndPos> entriesByTile = new ArrayList<>();
-		if (Arrays.stream(currentMenuEntries).anyMatch(this::isTakeClue))
+		if (areEntriesInTile(menuEntry))
 		{
-			entriesByTile = getEntriesByTile(currentMenuEntries);
+			return getTrackedClueText(menuEntryAndPos, showColor);
 		}
-
-		if (!entriesByTile.isEmpty())
-		{
-			return getTextForTrackedClue(menuEntryAndPos, showColor);
-		}
-
 		return null;
 	}
 
-	private String getTextForTrackedClue(MenuEntryAndPos entry, boolean showColor)
+	private String recolorText(MenuEntryAndPos menuEntryAndPos)
+	{
+		MenuEntry menuEntry = menuEntryAndPos.getMenuEntry();
+		int scrollID = getScrollID(menuEntry);
+
+		String itemName = Text.removeTags(menuEntry.getTarget());
+		String color;
+		Clues matchingClue = Clues.forItemId(scrollID);
+		if (matchingClue != null)
+		{
+			color = Integer.toHexString(matchingClue.getDetailColor(configManager).getRGB()).substring(2);
+			return "<col=" + color + ">" + itemName;
+		}
+
+		if (areEntriesInTile(menuEntry))
+		{
+			color = getTrackedClueColor(menuEntryAndPos);
+
+			if (color != null)
+			{
+				return "<col=" + color + ">" + itemName;
+			}
+		}
+		return null;
+	}
+
+	private ClueInstance getTrackedClueInstance(MenuEntryAndPos entry)
 	{
 		MenuEntry menuEntry = entry.getMenuEntry();
 		int sceneX = menuEntry.getParam0();
@@ -427,10 +528,31 @@ public class ClueDetailsOverlay extends OverlayPanel
 		List<ClueInstance> trackedClues = clueGroundManager.getGroundClues().get(itemWp);
 		if (trackedClues == null) return null;
 		// TODO: Fix, when a clue is picked up, posOnTile doesn't work any more. Needs shifting
-		ClueInstance clueInstance = trackedClues.get(entry.getPosOnTile());
+		return trackedClues.get(entry.getPosOnTile());
+	}
+
+	private String getTrackedClueText(MenuEntryAndPos entry, boolean showColor)
+	{
+		ClueInstance clueInstance = getTrackedClueInstance(entry);
 		if (clueInstance == null) return null;
 
-		return clueInstance.getCombinedClueText(configManager, showColor);
+		return clueInstance.getCombinedClueText(clueDetailsPlugin, configManager, showColor);
+	}
+
+	private String getTrackedClueColor(MenuEntryAndPos entry)
+	{
+		ClueInstance clueInstance = getTrackedClueInstance(entry);
+
+		// Ignore three-step cryptic clues
+		if (clueInstance != null && clueInstance.getClueIds().size() == 1)
+		{
+			Clues cluePart = Clues.forClueId(clueInstance.getClueIds().get(0));
+			if (cluePart != null)
+			{
+				return Integer.toHexString(cluePart.getDetailColor(configManager).getRGB()).substring(2);
+			}
+		}
+		return null;
 	}
 
 	@Subscribe

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -88,6 +88,9 @@ public class ClueDetailsPlugin extends Plugin
 	private ClueDetailsOverlay infoOverlay;
 
 	@Inject
+	private ClueGroundOverlay groundOverlay;
+
+	@Inject
 	private ClueDetailsTagsOverlay tagsOverlay;
 
 	@Inject
@@ -111,6 +114,7 @@ public class ClueDetailsPlugin extends Plugin
 	@Inject
 	private KeyManager keyManager;
 
+	@Getter
 	@Inject
 	private ItemManager itemManager;
 
@@ -150,6 +154,9 @@ public class ClueDetailsPlugin extends Plugin
 		overlayManager.add(infoOverlay);
 		eventBus.register(infoOverlay);
 
+		overlayManager.add(groundOverlay);
+		eventBus.register(groundOverlay);
+
 		overlayManager.add(tagsOverlay);
 
 		overlayManager.add(widgetOverlay);
@@ -162,6 +169,7 @@ public class ClueDetailsPlugin extends Plugin
 		clueBankManager.startUp(clueInventoryManager);
 
 		infoOverlay.startUp(this, clueGroundManager, clueInventoryManager);
+		groundOverlay.startUp(clueGroundManager);
 		widgetOverlay.setClueInventoryManager(clueInventoryManager);
 
 		final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "/icon.png");
@@ -185,6 +193,9 @@ public class ClueDetailsPlugin extends Plugin
 	{
 		overlayManager.remove(infoOverlay);
 		eventBus.unregister(infoOverlay);
+
+		overlayManager.remove(groundOverlay);
+		eventBus.unregister(groundOverlay);
 
 		overlayManager.remove(tagsOverlay);
 
@@ -282,10 +293,10 @@ public class ClueDetailsPlugin extends Plugin
 		clueGroundManager.onItemDespawned(event);
 	}
 
-	@Subscribe
+	@Subscribe(priority = -1) // run after ground items
 	public void onMenuEntryAdded(MenuEntryAdded event)
 	{
-		clueInventoryManager.onMenuEntryAdded(event, cluePreferenceManager, panel);
+		clueInventoryManager.onMenuEntryAdded(event, cluePreferenceManager, panel, config.showGroundClues());
 	}
 
 	@Subscribe

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -163,6 +163,7 @@ public class ClueDetailsPlugin extends Plugin
 		eventBus.register(widgetOverlay);
 
 		Clues.setConfig(config);
+		ClueInventoryManager.setConfig(config);
 
 		cluePreferenceManager = new CluePreferenceManager(configManager);
 		clueGroundManager = new ClueGroundManager(client, configManager, this);
@@ -298,7 +299,7 @@ public class ClueDetailsPlugin extends Plugin
 	@Subscribe(priority = -1) // run after ground items
 	public void onMenuEntryAdded(MenuEntryAdded event)
 	{
-		clueInventoryManager.onMenuEntryAdded(event, cluePreferenceManager, panel, config.showGroundClues());
+		clueInventoryManager.onMenuEntryAdded(event, cluePreferenceManager, panel);
 	}
 
 	@Subscribe

--- a/src/main/java/com/cluedetails/ClueGroundOverlay.java
+++ b/src/main/java/com/cluedetails/ClueGroundOverlay.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2024, TheLope <https://github.com/TheLope>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.cluedetails;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+import net.runelite.api.Player;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.TextComponent;
+import net.runelite.client.util.QuantityFormatter;
+import org.apache.commons.text.WordUtils;
+
+// Heavily lifted from net.runelite.client.plugins.grounditems.GroundItemsOverlay
+public class ClueGroundOverlay extends Overlay
+{
+	private static final int MAX_DISTANCE = 2500;
+	// We must offset the text on the z-axis such that
+	// it doesn't obscure the ground items below it.
+	private static final int OFFSET_Z = 20;
+	// Clue item height
+	private static final int CLUE_ITEM_HEIGHT = 0;
+	// The 15 pixel gap between each drawn ground item.
+	private static final int STRING_GAP = 15;
+
+	private final Client client;
+	private final ClueDetailsConfig config;
+	private final StringBuilder itemStringBuilder = new StringBuilder();
+	private final TextComponent textComponent = new TextComponent();
+	private final Map<WorldPoint, Integer> offsetMap = new HashMap<>();
+	private final ConfigManager configManager;
+	private final ClueDetailsPlugin plugin;
+	private ClueGroundManager clueGroundManager;
+
+	@Inject
+	private ClueGroundOverlay(ClueDetailsPlugin plugin, Client client, ClueDetailsConfig config, ConfigManager configManager)
+	{
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+		this.plugin = plugin;
+		this.client = client;
+		this.config = config;
+		this.configManager = configManager;
+	}
+
+	public void startUp(ClueGroundManager clueGroundManager)
+	{
+		this.clueGroundManager = clueGroundManager;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!config.showGroundClues())
+		{
+			return null;
+		}
+
+		final FontMetrics fm = graphics.getFontMetrics();
+		final Player player = client.getLocalPlayer();
+
+		if (player == null)
+		{
+			return null;
+		}
+
+		offsetMap.clear();
+		final LocalPoint localLocation = player.getLocalLocation();
+
+		// Handle beginner and master clues
+		for (WorldPoint wp : clueGroundManager.getGroundClues().keySet())
+		{
+			// Check if wp in clueGroundManager is within range of the player
+			final LocalPoint groundPoint = LocalPoint.fromWorld(client, wp);
+
+			if (groundPoint == null || localLocation.distanceTo(groundPoint) > MAX_DISTANCE)
+			{
+				continue;
+			}
+
+			// Get list of ClueInstances at wp with optionally collapsed quantities
+			Map<ClueInstance, Integer> clueInstancesAtWpMap = getClueInstancesAtWpMap(wp, client.getTickCount());
+
+			if (clueInstancesAtWpMap == null)
+			{
+				continue;
+			}
+
+			for (Map.Entry<ClueInstance, Integer> entry : clueInstancesAtWpMap.entrySet())
+			{
+				ClueInstance item = entry.getKey();
+				int quantity = entry.getValue();
+
+				renderClueInstanceGroundOverlay(graphics, item, quantity, groundPoint, fm);
+			}
+		}
+
+		return null;
+	}
+
+	private Map<ClueInstance, Integer> getClueInstancesAtWpMap(WorldPoint wp, int currentTick)
+	{
+		if (clueGroundManager.getGroundClues().get(wp).isEmpty()) return null;
+
+		List<ClueInstance> groundItemList = clueGroundManager.getGroundClues().get(wp);
+		Map<ClueInstance, Integer> groundItemMap = new HashMap<>();
+
+		if (config.collapseGroundClues())
+		{
+			groundItemMap = keepOldestUniqueClues(groundItemList, currentTick);
+		}
+		else
+		{
+			for (ClueInstance item : groundItemList)
+			{
+				groundItemMap.put(item, 1);
+			}
+		}
+		return groundItemMap;
+	}
+
+	private void renderClueInstanceGroundOverlay(Graphics2D graphics, ClueInstance item, int quantity, LocalPoint groundPoint, FontMetrics fm)
+	{
+		Color color = Color.WHITE;
+
+		if (item.getClueIds().isEmpty())
+		{
+			itemStringBuilder.append(item.getItemName(plugin));
+		}
+		else
+		{
+			int clueId = item.getClueIds().get(0);
+			Clues clueDetails = Clues.forClueId(clueId);
+
+			if (clueDetails == null)
+			{
+				return;
+			}
+
+			String clueText;
+			if (config.changeGroundClueText())
+			{
+				if (item.getClueIds().size() > 1)
+				{
+					clueText = "Three-step (master)";
+				}
+				else
+				{
+					clueText = clueDetails.getDetail(configManager);
+				}
+			}
+			else
+			{
+				clueText = WordUtils.capitalizeFully(clueDetails.getClueTier().toString());
+			}
+
+			itemStringBuilder.append(clueText);
+
+			if (config.colorGroundClues())
+			{
+				color = clueDetails.getDetailColor(configManager);
+			}
+		}
+
+		if (config.collapseGroundClues() && quantity > 1)
+		{
+			itemStringBuilder.append(" (")
+				.append(QuantityFormatter.quantityToStackSize(quantity))
+				.append(')');
+		}
+
+		final String itemString = itemStringBuilder.toString();
+		itemStringBuilder.setLength(0);
+
+		final Point textPoint = Perspective.getCanvasTextLocation(client,
+			graphics,
+			groundPoint,
+			itemString,
+			CLUE_ITEM_HEIGHT + OFFSET_Z);
+
+		if (textPoint == null)
+		{
+			return;
+		}
+
+		final int offset = offsetMap.compute(item.getLocation(), (k, v) -> v != null ? v + 1 : 0);
+
+		final int textX = textPoint.getX();
+		final int textY = textPoint.getY() - (STRING_GAP * offset);
+
+		if (config.showGroundCluesDespawn())
+		{
+			Integer despawnTime = item.getDespawnTick(client.getTickCount()) - client.getTickCount();
+			Color timerColor = Color.WHITE;
+
+			final String timerText = String.format(" - %d", despawnTime);
+
+			// The timer text is drawn separately to have its own color, and is intentionally not included
+			// in the getCanvasTextLocation() call because the timer text can change per frame and we do not
+			// use a monospaced font, which causes the text location on screen to jump around slightly each frame.
+			textComponent.setText(timerText);
+			textComponent.setColor(timerColor);
+			textComponent.setPosition(new java.awt.Point(textX + fm.stringWidth(itemString), textY));
+			textComponent.render(graphics);
+		}
+
+		textComponent.setText(itemString);
+		textComponent.setColor(color);
+		textComponent.setPosition(new java.awt.Point(textX, textY));
+		textComponent.render(graphics);
+	}
+
+	// Remove duplicate clues, maintaining a count of the original amount of each
+	public static Map<ClueInstance, Integer> keepOldestUniqueClues(List<ClueInstance> items, int currentTick) {
+		Map<List<Integer>, ClueInstance> lowestValueItems = new HashMap<>();
+		Map<List<Integer>, Integer> uniqueCount = new HashMap<>();
+
+		for (ClueInstance item : items) {
+			if (!lowestValueItems.containsKey(item.getClueIds()) || item.getDespawnTick(currentTick) < lowestValueItems.get(item.getClueIds()).getDespawnTick(currentTick)) {
+				lowestValueItems.put(item.getClueIds(), item);
+				uniqueCount.put(item.getClueIds(), 1);
+			} else {
+				uniqueCount.put(item.getClueIds(), uniqueCount.get(item.getClueIds()) + 1);
+			}
+		}
+
+		return lowestValueItems.values().stream()
+			.collect(Collectors.toMap(item -> item, item -> uniqueCount.get(item.getClueIds())));
+	}
+}

--- a/src/main/java/com/cluedetails/ClueGroundOverlay.java
+++ b/src/main/java/com/cluedetails/ClueGroundOverlay.java
@@ -87,6 +87,8 @@ public class ClueGroundOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if(clueGroundManager == null) return null;
+
 		if (!config.showGroundClues())
 		{
 			return null;
@@ -104,6 +106,12 @@ public class ClueGroundOverlay extends Overlay
 		final LocalPoint localLocation = player.getLocalLocation();
 
 		// Handle beginner and master clues
+		if (clueGroundManager.getGroundClues().keySet().isEmpty()
+			|| (!config.beginnerDetails() && !config.masterDetails()))
+		{
+			return null;
+		}
+
 		for (WorldPoint wp : clueGroundManager.getGroundClues().keySet())
 		{
 			// Check if wp in clueGroundManager is within range of the player
@@ -125,9 +133,12 @@ public class ClueGroundOverlay extends Overlay
 			for (Map.Entry<ClueInstance, Integer> entry : clueInstancesAtWpMap.entrySet())
 			{
 				ClueInstance item = entry.getKey();
-				int quantity = entry.getValue();
 
-				renderClueInstanceGroundOverlay(graphics, item, quantity, groundPoint, fm);
+				if(item.isEnabled(config))
+				{
+					int quantity = entry.getValue();
+					renderClueInstanceGroundOverlay(graphics, item, quantity, groundPoint, fm);
+				}
 			}
 		}
 
@@ -166,7 +177,7 @@ public class ClueGroundOverlay extends Overlay
 		else
 		{
 			int clueId = item.getClueIds().get(0);
-			Clues clueDetails = Clues.forClueId(clueId);
+			Clues clueDetails = Clues.forClueIdFiltered(clueId);
 
 			if (clueDetails == null)
 			{

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -29,6 +29,7 @@ import java.util.List;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
+import net.runelite.api.ItemID;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.config.ConfigManager;
@@ -134,5 +135,18 @@ public class ClueInstance
 	public String getItemName(ClueDetailsPlugin plugin)
 	{
 		return plugin.getItemManager().getItemComposition(itemId).getName();
+	}
+
+	public boolean isEnabled(ClueDetailsConfig config)
+	{
+		if (itemId == ItemID.CLUE_SCROLL_BEGINNER)
+		{
+			return config.beginnerDetails();
+		}
+		else if (itemId == ItemID.CLUE_SCROLL_MASTER )
+		{
+			return config.masterDetails();
+		}
+		return true;
 	}
 }

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -95,7 +95,7 @@ public class ClueInstance
 		return timeToDespawnFromDataInTicks == null ? -1 : timeToDespawnFromDataInTicks;
 	}
 
-	public String getCombinedClueText(ConfigManager configManager, boolean showColor)
+	public String getCombinedClueText(ClueDetailsPlugin plugin, ConfigManager configManager, boolean showColor)
 	{
 		StringBuilder returnText = new StringBuilder();
 		boolean isFirst = true;
@@ -120,7 +120,12 @@ public class ClueInstance
 
 			returnText.append(cluePart.getDetail(configManager));
 		}
-		if (returnText.length() == 0) return "Unknown, read to track";
+		if (returnText.length() == 0) return getItemName(plugin);
 		return returnText.toString();
+	}
+
+	public String getItemName(ClueDetailsPlugin plugin)
+	{
+		return plugin.getItemManager().getItemComposition(itemId).getName();
 	}
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/f115b2d9-3f06-451a-a952-2dd76f27e2d2

- Overlay may include: text, color, despawn timers, and collapse
- Assumes the player will hide beginner and master clues in Ground Items Plugin
    - Ground clues are not deprioritized when "Deprioritize menu hidden items" is enabled in Ground Items Plugin
- Fixes right click options for med keys and challenge scrolls via the addition/use of isClueItem
- Replaced instances of "Unknown, read to track" with the standard item text
- Changed ground items menu text now will also change the "Take" option text, meaning hover text is redundant in in that scenario