### PR TITLE
Three-step cryptic hover text

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -160,14 +160,16 @@ public class ClueDetailsOverlay extends OverlayPanel
 			return;
 		}
 
-		if (isTakeClue(menuEntry) && config.changeClueText())
+		String clueText = getText(menuEntryAndPos, config.colorHoverText(), false);
+
+		if (clueText == null) return;
+
+		// Hide tooltip when changeClueText enabled except for master three-step cryptic
+		if (isTakeClue(menuEntry) && config.changeClueText() && !clueText.contains("<br>"))
 		{
 			return;
 		}
 
-		String clueText = getText(menuEntryAndPos, config.colorHoverText(), false);
-
-		if (clueText == null) return;
 		// tooltip only supports </br> for multiline strings
 		String tooltipClueText = clueText.replaceAll("<br>", "</br>");
 		tooltipManager.add(new Tooltip(tooltipClueText));


### PR DESCRIPTION
Hide tooltip when changeClueText enabled except for master three-step cryptic

Hover text shows additional information only for master three-step cryptic clues
![image](https://github.com/user-attachments/assets/ce842f4f-ba5d-43f6-b536-3ece5b8ac7a4)
![image](https://github.com/user-attachments/assets/0e47c540-75b2-444c-8bc1-4f63e1e437c0)

