### PR TITLE
Ground item menu color fix

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -503,22 +503,23 @@ public class ClueDetailsOverlay extends OverlayPanel
 		int scrollID = getScrollID(menuEntry);
 
 		String itemName = Text.removeTags(menuEntry.getTarget());
-		String color;
+		Color color = null;
+
 		Clues matchingClue = Clues.forItemId(scrollID);
 		if (matchingClue != null)
 		{
-			color = Integer.toHexString(matchingClue.getDetailColor(configManager).getRGB()).substring(2);
-			return "<col=" + color + ">" + itemName;
+			color = matchingClue.getDetailColor(configManager);
 		}
-
-		if (areEntriesInTile(menuEntry))
+		else if (areEntriesInTile(menuEntry))
 		{
 			color = getTrackedClueColor(menuEntryAndPos);
+		}
 
-			if (color != null)
-			{
-				return "<col=" + color + ">" + itemName;
-			}
+		// Only change ground item menu color if it's not the default
+		if (color != null && color != Color.WHITE)
+		{
+			String hexColor = Integer.toHexString(color.getRGB()).substring(2);
+			return "<col=" + hexColor + ">" + itemName;
 		}
 		return null;
 	}
@@ -545,7 +546,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 		return clueInstance.getCombinedClueText(clueDetailsPlugin, configManager, showColor, isFloorText);
 	}
 
-	private String getTrackedClueColor(MenuEntryAndPos entry)
+	private Color getTrackedClueColor(MenuEntryAndPos entry)
 	{
 		ClueInstance clueInstance = getTrackedClueInstance(entry);
 
@@ -555,7 +556,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 			Clues cluePart = Clues.forClueIdFiltered(clueInstance.getClueIds().get(0));
 			if (cluePart != null)
 			{
-				return Integer.toHexString(cluePart.getDetailColor(configManager).getRGB()).substring(2);
+				return cluePart.getDetailColor(configManager);
 			}
 		}
 		return null;


### PR DESCRIPTION
Ground item menu color was being inadvertently changed to white

On a fresh profile:
![image](https://github.com/user-attachments/assets/7c6f475f-6a4a-4b52-9ba6-a534604cd6ac)
