### PR TITLE
Ability to reset Ground Items and Inventory Tags colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ Colors will now be updated for the specific clue depending on the configuration 
 
 Updating Ground Items and Inventory Tags colors is also supported. 
 
-- Enable the "Overwrite ..." configuration options in the "Overlay Colors" section prior to editing colors. This is applied at the time the colors are edited/imported.
-    - Resetting Ground Items and Inventory Tags colors must be done via those plugins.
+- Enable the "Overwrite ..." configuration option(s) in the "Overlay Colors" section.
+    - This is applied only at the time the colors are edited/imported.
+    - Does apply to Beginner and Master clues.
+    - Resetting Ground Items and Inventory Tags colors can must be done via setting the clue's color to white (#FFFFFF).
 
 ### Items
 You can edit the clue details items for each clue, this can be done 3 different ways.

--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -474,7 +474,7 @@ public interface ClueDetailsConfig extends Config
 		keyName = "colorGroundItems",
 		name = "Overwrite Ground Items colors",
 		description = "When updating clue details colors, apply the color to the Ground Items plugin",
-		warning = "Does not work for Beginner and Master clues. Colors must be reset via Ground Items plugin.",
+		warning = "Does apply to Beginner and Master clues. Set color to #FFFFFF to reset.",
 		section = overlayColorsSection,
 		position = 5
 	)
@@ -487,7 +487,7 @@ public interface ClueDetailsConfig extends Config
 		keyName = "colorInventoryTags",
 		name = "Overwrite Inventory Tags colors",
 		description = "When updating clue details colors, apply the color to the Inventory Tags plugin",
-		warning = "Does not work for Beginner and Master clues. Colors must be reset via Inventory Tags plugin.",
+		warning = "Does apply to Beginner and Master clues. Set color to #FFFFFF to reset.",
 		section = overlayColorsSection,
 		position = 6
 	)

--- a/src/main/java/com/cluedetails/ClueDetailsSharingManager.java
+++ b/src/main/java/com/cluedetails/ClueDetailsSharingManager.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -254,30 +253,45 @@ public class ClueDetailsSharingManager
 			}
 			if (importPoint.color != null)
 			{
-				// Default color is white, so we don't need to store if user selects white
-				if (Objects.equals(importPoint.color, Color.decode("#FFFFFF")))
+				// Default color is white, so white is used to unset configurations
+				if (ClueIdToDetails.equalRGB(importPoint.color, Color.WHITE))
 				{
 					configManager.unsetConfiguration("clue-details-color", String.valueOf(importPoint.id));
+
+					// Reset Ground Items and Inventory Tags
+					// Beginner & master clues are not supported by these plugins
+					if (importPoint.id >= 2677)
+					{
+						if (config.colorGroundItems())
+						{
+							configManager.unsetConfiguration(GroundItemsConfig.GROUP, "highlight_" + importPoint.id);
+						}
+						if (config.colorInventoryTags())
+						{
+							configManager.unsetConfiguration(InventoryTagsConfig.GROUP, "tag_" + importPoint.id);
+						}
+					}
 				}
 				else
 				{
 					configManager.setConfiguration("clue-details-color", String.valueOf(importPoint.id), importPoint.color);
-				}
 
-				// Ground Items and Inventory Tags cannot support unique colors for beginner & master clues
-				if (importPoint.id >= 2677 && (config.colorGroundItems() || config.colorInventoryTags()))
-				{
-					// Ensure ARGB format
-					Color color = Color.decode(configManager.getConfiguration("clue-details-color", String.valueOf(importPoint.id)));
+					// Apply color to Ground Items and Inventory Tags
+					// Beginner & master clues are not supported by these plugins
+					if (importPoint.id >= 2677)
+					{
+						// Ensure ARGB format
+						Color color = Color.decode(configManager.getConfiguration("clue-details-color", String.valueOf(importPoint.id)));
 
-					if (config.colorGroundItems())
-					{
-						configManager.setConfiguration(GroundItemsConfig.GROUP, "highlight_" + importPoint.id, color);
-					}
-					if (config.colorInventoryTags())
-					{
-						configManager.setConfiguration(InventoryTagsConfig.GROUP, "tag_" + importPoint.id,
-							gson.toJson(Map.of("color", color)));
+						if (config.colorGroundItems())
+						{
+							configManager.setConfiguration(GroundItemsConfig.GROUP, "highlight_" + importPoint.id, color);
+						}
+						if (config.colorInventoryTags())
+						{
+							configManager.setConfiguration(InventoryTagsConfig.GROUP, "tag_" + importPoint.id,
+								gson.toJson(Map.of("color", color)));
+						}
 					}
 				}
 			}

--- a/src/main/java/com/cluedetails/ClueIdToDetails.java
+++ b/src/main/java/com/cluedetails/ClueIdToDetails.java
@@ -82,4 +82,13 @@ public class ClueIdToDetails
 		this.color = color;
 		this.itemIds = itemIds;
 	}
+
+	public static boolean equalRGB(Color color1, Color color2)
+	{
+		int deltaRed = color1.getRed() - color2.getRed();
+		int deltaGreen = color1.getGreen() - color2.getGreen();
+		int deltaBlue = color1.getBlue() - color2.getBlue();
+
+		return (deltaRed + deltaGreen + deltaBlue) == 0;
+	}
 }


### PR DESCRIPTION
Previously, users needed to use the right click options on each individual clue in order to reset colors

![TrBkmLu](https://github.com/user-attachments/assets/c89f205c-b9dd-4867-9f31-eaabdaffdfce)