### PR TITLE
Implemented inventory tags for clue scrolls and clue items

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ The "Change ground item menu text" toggle in the plugin's settings adjusts the a
 
 ![Screenshot 2024-09-01 221305](https://github.com/user-attachments/assets/72685ba5-f441-4cac-b18c-6cc0ddf42d98)
 
-The "Highlight inventory clue items" toggle highlights configured items for each clue in your inventory
+The "Inventory tag clue scrolls" toggle applies inventory tags to clues in your inventory using configured clue colors
+
+![image](https://github.com/user-attachments/assets/ba9ca49f-df55-48c5-a112-5302ecef1683)
+
+The "Inventory tag clue items" toggle applies inventory tags configured items for each clue in your inventory
 
 ![image](https://github.com/user-attachments/assets/3dc33f5b-f300-4614-b6bf-db7359f23ae5)
 
@@ -75,9 +79,9 @@ Updating Ground Items and Inventory Tags colors is also supported.
 
 ### Items
 You can edit the clue details items for each clue, this can be done 3 different ways.
-1. If you have the clue in your inventory for which you would like to highlight an item:
+1. If you have the clue in your inventory for which you would like to inventory tag an item:
     - Right-click the desired inventory item and choose "Add" or "Remove" for the clue via the option specifying its tier
-2. In the sidebar, right-click the clue you would like to highlight an item for, and select "Add/Remove item"
+2. In the sidebar, right-click the clue you would like to inventory tag an item for, and select "Add/Remove item"
 3. Via Import/Export. See below
 
 ## Import/Export clue details

--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -383,28 +383,29 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highlightInventoryClueItems",
-		name = "Highlight inventory clue items",
-		description = "Toggle whether to highlight configured items for each clue in your inventory",
+		keyName = "highlightInventoryClueScrolls",
+		name = "Inventory tag clue scrolls",
+		warning = "Display mode is managed by Inventory Tags configuration",
+		description = "Toggle whether to apply inventory tags to clues with clue details color",
 		section = overlaysSection,
 		position = 6
+	)
+	default boolean highlightInventoryClueScrolls()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "highlightInventoryClueItems",
+		name = "Inventory tag clue items",
+		warning = "Display mode is managed by Inventory Tags configuration",
+		description = "Toggle whether to apply inventory tags to configured items for each clue in your inventory",
+		section = overlaysSection,
+		position = 7
 	)
 	default boolean highlightInventoryClueItems()
 	{
 		return true;
-	}
-
-	@Alpha
-	@ConfigItem(
-		keyName = "itemHighlightColor",
-		name = "Item highlight color",
-		description = "Configures the default color for highlighted inventory clue items",
-		section = overlaysSection,
-		position = 7
-	)
-	default Color itemHighlightColor()
-	{
-		return Color.YELLOW.darker();
 	}
 
 	@ConfigSection(name = "Overlay Colors", description = "Options that effect overlay colors", position = 5)
@@ -460,8 +461,8 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "colorInventoryClueItems",
-		name = "Color inventory clue items",
-		description = "Toggle whether apply clue details color to highlighted inventory clue items",
+		name = "Color clue items",
+		description = "Toggle whether apply clue details color to clue items inventory tags",
 		section = overlayColorsSection,
 		position = 4
 	)
@@ -470,13 +471,26 @@ public interface ClueDetailsConfig extends Config
 		return true;
 	}
 
+	@Alpha
+	@ConfigItem(
+		keyName = "itemHighlightColor",
+		name = "Clue items color",
+		description = "Clue items inventory tag color used when Color clue items is toggled off",
+		section = overlayColorsSection,
+		position = 5
+	)
+	default Color itemHighlightColor()
+	{
+		return Color.YELLOW.darker();
+	}
+
 	@ConfigItem(
 		keyName = "colorGroundItems",
 		name = "Overwrite Ground Items colors",
 		description = "When updating clue details colors, apply the color to the Ground Items plugin",
 		warning = "Does apply to Beginner and Master clues. Set color to #FFFFFF to reset.",
 		section = overlayColorsSection,
-		position = 5
+		position = 7
 	)
 	default boolean colorGroundItems()
 	{

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -236,6 +236,7 @@ public class ClueDetailsPlugin extends Plugin
 	{
 		if (event.getContainerId() == InventoryID.INVENTORY.getId())
 		{
+			itemsOverlay.invalidateCache();
 			clueInventoryManager.updateInventory(event.getItemContainer());
 		}
 		else if (event.getContainerId() == InventoryID.BANK.getId())
@@ -328,6 +329,15 @@ public class ClueDetailsPlugin extends Plugin
 		if (event.getGroup().equals("clue-details-highlights"))
 		{
 			infoOverlay.refreshHighlights();
+		}
+
+		if (event.getGroup().equals("clue-details-color")
+			|| event.getGroup().equals("clue-details-items")
+			|| event.getKey().equals("highlightInventoryClueScrolls")
+			|| event.getKey().equals("highlightInventoryClueItems")
+			|| event.getKey().equals("colorInventoryClueItems"))
+		{
+			itemsOverlay.invalidateCache();
 		}
 
 		if (!event.getGroup().equals(ClueDetailsConfig.class.getAnnotation(ConfigGroup.class).value()))


### PR DESCRIPTION
Inventory tags are able to be rendered on clue scrolls and configured clue items
**If the implementation matches my intentions, only clue scrolls currently found in `cluesInInventory` should be tagged, and only items for those clues should be tagged**
![image](https://github.com/user-attachments/assets/6b2a380d-99dd-446c-b0d5-5ddd2a8d3330)
![6o6gLB1](https://github.com/user-attachments/assets/88a699d3-9f46-49a0-86e2-f4b0ca2871a7)

Inventory tag display mode is managed by Inventory Tags plugin configuration settings
![8xM0ZDX](https://github.com/user-attachments/assets/12b3b25e-320e-4806-83a8-0d68141d2473)

Inventory Tags plugin is allowed to draw over our Inventory tag implementation
![DV0Dbfm](https://github.com/user-attachments/assets/00275396-fe44-432d-81eb-203c6a012699)
