### PR TITLE
Easy->Elite Ground Clues Overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The "Inventory tag clue items" toggle applies inventory tags configured items fo
 
 ![image](https://github.com/user-attachments/assets/3dc33f5b-f300-4614-b6bf-db7359f23ae5)
 
-The "Show ground clues" toggle shows text overlay for Beginner and Master ground clues, similar to the Ground Items plugin.
+The "Show ground clues" toggle shows text overlay for ground clues, similar to the Ground Items plugin.
 
 ![ground_clues](https://github.com/user-attachments/assets/bb067da3-faaf-4d5f-a521-d1c3b030ab9b)
 

--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -551,8 +551,8 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "collapseGroundClues",
-		name = "Collapse ground clues",
-		description = "Toggle whether to combine duplicates in the ground clues overlay",
+		name = "Collapse ground clues by step",
+		description = "Toggle whether to combine duplicate steps in the ground clues overlay",
 		section = groundCluesSection,
 		position = 3
 	)
@@ -562,11 +562,24 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "collapseGroundCluesByTier",
+		name = "Collapse ground clues by tier",
+		description = "Toggle whether to combine duplicate tiers in the ground clues overlay" +
+			"<br><i>Not compatible with 'Change ground clue text'</i>",
+		section = groundCluesSection,
+		position = 4
+	)
+	default boolean collapseGroundCluesByTier()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "colorGroundClues",
 		name = "Color ground clues",
 		description = "Toggle whether to apply clue details color to ground clue text",
 		section = groundCluesSection,
-		position = 4
+		position = 5
 	)
 	default boolean colorGroundClues()
 	{

--- a/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
@@ -124,7 +124,8 @@ public class ClueDetailsItemsOverlay extends WidgetItemOverlay
 			ClueInstance instance = clueInventoryManager.getTrackedClueByClueItemId(itemID);
 			if (instance == null) continue;
 
-			instance.getClueIds().forEach((clueId) -> {
+			instance.getClueIds().forEach((clueId) ->
+			{
 				Clues clue = Clues.forClueIdFiltered(clueId);
 				if (clue == null) return;
 				if (isEnabled(clue))

--- a/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
@@ -104,7 +104,7 @@ public class ClueDetailsItemsOverlay extends WidgetItemOverlay
 		{
 			if (clue == null) continue;
 
-			if (isEnabled(clue))
+			if (clue.isEnabled(config))
 			{
 				if (config.highlightInventoryClueScrolls())
 				{
@@ -128,7 +128,7 @@ public class ClueDetailsItemsOverlay extends WidgetItemOverlay
 			{
 				Clues clue = Clues.forClueIdFiltered(clueId);
 				if (clue == null) return;
-				if (isEnabled(clue))
+				if (clue.isEnabled(config))
 				{
 					if (config.highlightInventoryClueScrolls())
 					{

--- a/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
@@ -30,13 +30,12 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import net.runelite.api.ItemID;
-import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 import net.runelite.client.ui.overlay.components.TextComponent;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 {
@@ -56,75 +55,66 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 	@Override
 	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem)
 	{
-		if (config.showInventoryClueTags())
+		if (!config.showInventoryClueTags()) return;
+
+		Clues clue = Clues.forItemId(itemId);
+
+		// If it's an easy-elite clue (so id=clue step)
+		if (clue != null && clue.isEnabled(config))
 		{
-			Clues clue = Clues.forItemId(itemId);
-			String clueDetail = null;
-			Color clueDetailColor = Color.WHITE;
-
-			if (clue != null
-				&& !(itemId >= InterfaceID.CLUE_BEGINNER_MAP_CHAMPIONS_GUILD
-					&& itemId <= InterfaceID.CLUE_BEGINNER_MAP_WIZARDS_TOWER))
-			{
-				clueDetail = clue.getDetail(configManager);
-				clueDetailColor = clue.getDetailColor(configManager);
-			}
-			// If clue can't be found by Clue ID, check if it can be found by Clue text
-			else
-			{
-				if (Clues.isClue(itemId, clueDetailsPlugin.isDeveloperMode())
-					&& clueDetailsPlugin.getClueInventoryManager().hasTrackedClues())
-				{
-					// Check if clue tier is enabled
-					if (((itemId == ItemID.CLUE_SCROLL_BEGINNER || (itemId >= InterfaceID.CLUE_BEGINNER_MAP_CHAMPIONS_GUILD
-						&& itemId <= InterfaceID.CLUE_BEGINNER_MAP_WIZARDS_TOWER)) && !config.beginnerDetails())
-						|| itemId == ItemID.CLUE_SCROLL_MASTER && !config.masterDetails())
-					{
-						return;
-					}
-
-					ClueInstance readClues = clueDetailsPlugin.getClueInventoryManager().getTrackedClueByClueItemId(itemId);
-					if (readClues == null)
-					{
-						return;
-					}
-					List<Integer> ids = readClues.getClueIds();
-
-					if (ids.isEmpty()) return;
-
-					boolean isFirst = true;
-					StringBuilder text = new StringBuilder();
-					StringBuilder detail = new StringBuilder();
-					for (Integer id : ids)
-					{
-						Clues clueDetails = Clues.forClueIdFiltered(id);
-						if (!isFirst)
-						{
-							text.append("<br>");
-							detail.append("<br>");
-						}
-						text.append(clueDetails == null ? "error" : clueDetails.getClueText());
-						detail.append(clueDetails == null ? "error" : clueDetails.getDetail(configManager));
-						clueDetailColor = clueDetails == null ? Color.WHITE : clueDetails.getDetailColor(configManager);
-						isFirst = false;
-					}
-
-					// Handle three step cryptic clues
-					final ThreeStepCrypticClue threeStepCrypticClue = ThreeStepCrypticClue.forText(text.toString());
-					if (threeStepCrypticClue != null)
-					{
-						threeStepCrypticClue.update(clueDetailsPlugin.getClueInventoryManager().getTrackedCluesInInventory());
-						clueDetail = threeStepCrypticClue.getDetail(configManager, config);
-						clueDetailColor = Color.WHITE;
-					}
-					else
-					{
-						clueDetail = detail.toString();
-					}
-				}
-			}
-			renderText(graphics, widgetItem.getCanvasBounds(), clueDetail, clueDetailColor);
+			renderText(graphics, widgetItem.getCanvasBounds(), clue.getDetail(configManager), clue.getDetailColor(configManager));
+			return;
 		}
+
+		// Check if it's a beginner/master clue
+		ClueInstance readClues = clueDetailsPlugin.getClueInventoryManager().getTrackedClueByClueItemId(itemId);
+		if (readClues == null || !readClues.isEnabled(config)) return;
+
+		List<Integer> ids = readClues.getClueIds();
+
+		if (ids.isEmpty()) return;
+
+		Pair<String, Color> textAndColor = getClueTextFromClueIds(ids);
+
+		renderText(graphics, widgetItem.getCanvasBounds(), textAndColor.getLeft(), textAndColor.getRight());
+	}
+
+	private Pair<String, Color> getClueTextFromClueIds(List<Integer> ids)
+	{
+		String clueDetail = null;
+		Color clueDetailColor = Color.WHITE;
+
+		boolean isFirst = true;
+		StringBuilder text = new StringBuilder();
+		StringBuilder detail = new StringBuilder();
+		for (Integer id : ids)
+		{
+			Clues clueDetails = Clues.forClueIdFiltered(id);
+			if (!isFirst)
+			{
+				text.append("<br>");
+				detail.append("<br>");
+			}
+			text.append(clueDetails == null ? "error" : clueDetails.getClueText());
+			detail.append(clueDetails == null ? "error" : clueDetails.getDetail(configManager));
+			clueDetailColor = clueDetails == null ? Color.WHITE : clueDetails.getDetailColor(configManager);
+			isFirst = false;
+		}
+
+		// Handle three step cryptic clues
+		final ThreeStepCrypticClue threeStepCrypticClue = ThreeStepCrypticClue.forText(text.toString());
+		if (threeStepCrypticClue != null)
+		{
+			threeStepCrypticClue.update(clueDetailsPlugin.getClueInventoryManager().getTrackedCluesInInventory());
+			clueDetail = threeStepCrypticClue.getDetail(configManager, config);
+			clueDetailColor = Color.WHITE;
+		}
+		else
+		{
+			clueDetail = detail.toString();
+		}
+
+		return Pair.of(clueDetail, clueDetailColor);
 	}
 
 	public int textPosition(Graphics2D graphics, Rectangle bounds, int i, int detailCount)

--- a/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
@@ -72,7 +72,7 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 			// If clue can't be found by Clue ID, check if it can be found by Clue text
 			else
 			{
-				if (Clues.isTrackedClue(itemId, clueDetailsPlugin.isDeveloperMode())
+				if (Clues.isClue(itemId, clueDetailsPlugin.isDeveloperMode())
 					&& clueDetailsPlugin.getClueInventoryManager().hasTrackedClues())
 				{
 					// Check if clue tier is enabled

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -67,7 +67,7 @@ public class ClueGroundManager
 		// If log in on tile with clues on it, spawned. Won't be dropped, but could be dropped?
 		// Main issue is we don't want to create a new groundClue if it was dropped, as we will then also be doing another new one after.
 		TileItem item = event.getItem();
-		if (!Clues.isTrackedClueOrTornClue(item.getId(), clueDetailsPlugin.isDeveloperMode())) return;
+		if (!Clues.isClue(item.getId(), clueDetailsPlugin.isDeveloperMode())) return;
 		if (checkIfItemMatchesKnownItem(event.getTile(), item, event.getTile().getWorldLocation())) return;
 
 		// New despawn timer, probably been dropped. Track to see what it was.
@@ -86,7 +86,7 @@ public class ClueGroundManager
 	public void onItemDespawned(ItemDespawned event)
 	{
 		TileItem item = event.getItem();
-		if (!Clues.isTrackedClueOrTornClue(item.getId(), clueDetailsPlugin.isDeveloperMode())) return;
+		if (!Clues.isClue(item.getId(), clueDetailsPlugin.isDeveloperMode())) return;
 		WorldPoint location = event.getTile().getWorldLocation();
 		List<ClueInstance> cluesAtLocation = groundClues.get(location);
 
@@ -191,7 +191,8 @@ public class ClueGroundManager
 
 	private void processEmptyTiles()
 	{
-		groundClues.entrySet().removeIf(entry -> {
+		groundClues.entrySet().removeIf(entry ->
+		{
 			Tile tile = getTileAtWorldPoint(entry.getKey());
 			if (tile == null) return false;
 
@@ -424,7 +425,7 @@ public class ClueGroundManager
 			return Collections.emptyList();
 		}
 		return items.stream()
-			.filter(item -> Clues.isTrackedClueOrTornClue(item.getId(), clueDetailsPlugin.isDeveloperMode()))
+			.filter(item -> Clues.isClue(item.getId(), clueDetailsPlugin.isDeveloperMode()))
 			.collect(Collectors.toList());
 	}
 

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -24,7 +24,9 @@
  */
 package com.cluedetails;
 
+import com.cluedetails.filters.ClueTier;
 import java.awt.Color;
+import java.util.Collections;
 import java.util.List;
 import lombok.Data;
 import lombok.Getter;
@@ -75,6 +77,35 @@ public class ClueInstance
 		this.location = location;
 		this.tileItem = tileItem;
 		this.timeToDespawnFromDataInTicks = currentTick;
+	}
+
+	public List<Integer> getClueIds()
+	{
+		if (clueIds.isEmpty() && !(itemId == ItemID.CLUE_SCROLL_BEGINNER || itemId == ItemID.CLUE_SCROLL_MASTER))
+		{
+			return Collections.singletonList(itemId);
+		}
+		return clueIds;
+	}
+
+	public ClueTier getTier()
+	{
+		Clues clue;
+
+		if (clueIds.isEmpty())
+		{
+			clue = Clues.forItemId(itemId);
+		}
+		else
+		{
+			clue = Clues.forClueId(getClueIds().get(0));
+		}
+
+		if (clue == null)
+		{
+			return null;
+		}
+		return clue.getClueTier();
 	}
 
 	public int getDespawnTick(int currentTick)
@@ -143,7 +174,23 @@ public class ClueInstance
 		{
 			return config.beginnerDetails();
 		}
-		else if (itemId == ItemID.CLUE_SCROLL_MASTER )
+		else if (getTier() == ClueTier.EASY)
+		{
+			return config.easyDetails();
+		}
+		else if (getTier() == ClueTier.MEDIUM)
+		{
+			return config.mediumDetails();
+		}
+		else if (getTier() == ClueTier.HARD)
+		{
+			return config.hardDetails();
+		}
+		else if (getTier() == ClueTier.ELITE)
+		{
+			return config.eliteDetails();
+		}
+		else if (itemId == ItemID.CLUE_SCROLL_MASTER)
 		{
 			return config.masterDetails();
 		}

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -35,6 +35,8 @@ import net.runelite.api.ItemID;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.util.QuantityFormatter;
+import org.apache.commons.text.WordUtils;
 
 @Data
 public class ClueInstance
@@ -106,6 +108,77 @@ public class ClueInstance
 			return null;
 		}
 		return clue.getClueTier();
+	}
+
+	public String getGroundText(ClueDetailsPlugin plugin, ClueDetailsConfig config, ConfigManager configManager, int quantity)
+	{
+		StringBuilder itemStringBuilder = new StringBuilder();
+		List<Integer> clueIds = this.getClueIds();
+
+		if (clueIds.isEmpty())
+		{
+			itemStringBuilder.append(this.getItemName(plugin));
+		}
+		else
+		{
+			int clueId = this.getClueIds().get(0);
+			Clues clueDetails = Clues.forClueIdFiltered(clueId);
+
+			if (clueDetails == null)
+			{
+				return null;
+			}
+
+			String clueText;
+			if (config.changeGroundClueText() && !config.collapseGroundCluesByTier())
+			{
+				if (clueIds.size() > 1)
+				{
+					clueText = "Three-step (master)";
+				}
+				else
+				{
+					clueText = clueDetails.getDetail(configManager);
+				}
+			}
+			else
+			{
+				clueText = WordUtils.capitalizeFully(clueDetails.getClueTier().toString().replace("_", " "));
+			}
+
+			itemStringBuilder.append(clueText);
+		}
+
+		if ((config.collapseGroundClues() || config.collapseGroundCluesByTier()) && quantity > 1)
+		{
+			itemStringBuilder.append(" (")
+				.append(QuantityFormatter.quantityToStackSize(quantity))
+				.append(')');
+		}
+		return itemStringBuilder.toString();
+	}
+
+	public Color getGroundColor(ClueDetailsConfig config, ConfigManager configManager)
+	{
+		Color color = Color.WHITE;
+		List<Integer> clueIds = this.getClueIds();
+
+		if (!clueIds.isEmpty())
+		{
+			int clueId = this.getClueIds().get(0);
+			Clues clueDetails = Clues.forClueIdFiltered(clueId);
+
+			if (clueDetails == null)
+			{
+				return color;
+			}
+
+			if (config.colorGroundClues())
+			{
+				color = clueDetails.getDetailColor(configManager);
+			}
+		}
+		return color;
 	}
 
 	public int getDespawnTick(int currentTick)
@@ -194,6 +267,6 @@ public class ClueInstance
 		{
 			return config.masterDetails();
 		}
-		return true;
+		else return getTier() != null;
 	}
 }

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1211,14 +1211,9 @@ public class Clues
 		return filteredClues().stream().anyMatch((clue) -> clue.getItemID() == itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
 	}
 
-	public static boolean isTrackedClue(int itemId, boolean isDeveloperMode)
-	{
-		return TRACKED_CLUE_IDS.contains(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
-	}
-
 	public static boolean isTrackedClueOrTornClue(int itemId, boolean isDeveloperMode)
 	{
-		return TRACKED_CLUE_IDS.contains(itemId) || TRACKED_TORN_CLUE_IDS.contains(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
+		return isClue(itemId, isDeveloperMode) || TRACKED_TORN_CLUE_IDS.contains(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
 	}
 
 	public static Collection<Integer> getTrackedClueAndTornClueIds(boolean isDevMode)

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1224,4 +1224,37 @@ public class Clues
 		if (isDevMode) allIds.addAll(DEV_MODE_IDS);
 		return allIds;
 	}
+
+	public boolean isEnabled(ClueDetailsConfig config)
+	{
+		ClueTier tier = getClueTier();
+
+		if (config == null) return true;
+
+		if (tier == ClueTier.BEGINNER)
+		{
+			return config.beginnerDetails();
+		}
+		if (tier == ClueTier.EASY)
+		{
+			return config.easyDetails();
+		}
+		if (tier == ClueTier.MEDIUM || tier == ClueTier.MEDIUM_CHALLENGE || tier == ClueTier.MEDIUM_KEY)
+		{
+			return config.mediumDetails();
+		}
+		if (tier == ClueTier.HARD || tier == ClueTier.HARD_CHALLENGE)
+		{
+			return config.hardDetails();
+		}
+		if (tier == ClueTier.ELITE || tier == ClueTier.ELITE_CHALLENGE)
+		{
+			return config.eliteDetails();
+		}
+		if (tier == ClueTier.MASTER)
+		{
+			return config.masterDetails();
+		}
+		return true;
+	}
 }


### PR DESCRIPTION
I would like to merge #101 #102 #104 first

- Tracked clues now includes all clue scrolls. Previously was limited to beginner and master clues
    - This enables the expansion of the ground clues feature -- e.g. #106
- Ground clues includes configuration options including collapsing by tier or step
    - ![SJWw16x](https://github.com/user-attachments/assets/d48e9742-d7d1-4a1d-8117-b60528bd50ec)
- Updated OverlayLayer to draw ground clues over the player for easier juggling

Did not notice any performance issues in my limited testing but it's possible tracking all clues causes issues not experienced while only beginners and masters were tracked