### PR TITLE
fix: clue timers notifications use shouldNotify

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.example'
-version = '2.3.1'
+version = '2.3.2'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -590,7 +590,7 @@ public interface ClueDetailsConfig extends Config
 		keyName = "showGroundClueTimers",
 		name = "Show ground clue timers",
 		description = "Toggle whether to show timer infoboxes for ground clues",
-		warning = "Experimental feature! Behavior is not correct across logouts, notifications misbehave, etc.",
+		warning = "Experimental feature! Timers may not behave as expected. Please use caution",
 		section = groundCluesSection,
 		position = 6
 	)

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -331,10 +331,14 @@ public class ClueDetailsPlugin extends Plugin
 			{
 				for (ClueGroundTimer timer : clueGroundTimers)
 				{
-					if (!timer.isNotified() && timer.getDuration().compareTo(Duration.ofSeconds(config.groundClueTimersNotificationTime())) < 0)
+					if (!timer.isNotified() && timer.shouldNotify())
 					{
 						notifier.notify("Your clue scroll is about to disappear!");
 						timer.setNotified(true);
+					}
+					else if (timer.isNotified() && !timer.shouldNotify())
+					{
+						timer.setNotified(false);
 					}
 				}
 			}

--- a/src/main/java/com/cluedetails/ClueGroundTimer.java
+++ b/src/main/java/com/cluedetails/ClueGroundTimer.java
@@ -47,11 +47,16 @@ class ClueGroundTimer extends Timer
 		this.clueInstancesWithQuantity = clueInstancesWithQuantityAtWp;
 	}
 
+	private int getSecondsLeft()
+	{
+		Duration timeLeft = Duration.between(Instant.now(), this.getEndTime());
+		return (int)(timeLeft.toMillis() / 1000L);
+	}
+
 	@Override
 	public String getText()
 	{
-		Duration timeLeft = Duration.between(Instant.now(), this.getEndTime());
-		int seconds = (int)(timeLeft.toMillis() / 1000L);
+		int seconds = getSecondsLeft();
 		int minutes = seconds / 60;
 		int secs = seconds % 60;
 		if (minutes < 1)
@@ -92,7 +97,7 @@ class ClueGroundTimer extends Timer
 	@Override
 	public Color getTextColor()
 	{
-		return getDuration().compareTo(Duration.ofSeconds(config.groundClueTimersNotificationTime())) < 0
+		return shouldNotify()
 			? Color.RED
 			: Color.WHITE;
 	}
@@ -125,5 +130,10 @@ class ClueGroundTimer extends Timer
 			}
 		}
 		return false;
+	}
+
+	public boolean shouldNotify()
+	{
+		return getSecondsLeft() < config.groundClueTimersNotificationTime();
 	}
 }


### PR DESCRIPTION
Clue timers notifications behaviour should now match the following:

The oldest clue in a pile's despawn time has surpassed the configured time, and a notification has not yet been sent for that particular clue

Updating the "Timer notifications" should also trigger notifications when appropriate

Timer text color should be red when a notification has been sent