### PR TITLE
Various bugfixes

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
@@ -24,7 +24,6 @@
  */
 package com.cluedetails;
 
-import com.cluedetails.filters.ClueTier;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.awt.Color;
@@ -99,25 +98,6 @@ public class ClueDetailsItemsOverlay extends WidgetItemOverlay
 		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
 		if (inventory == null || clueInventoryManager == null ) return;
 
-		// Highlight for easy-elite clues
-		for (Clues clue : clueInventoryManager.getCluesInInventory())
-		{
-			if (clue == null) continue;
-
-			if (clue.isEnabled(config))
-			{
-				if (config.highlightInventoryClueScrolls())
-				{
-					cacheClueScrolls(clue);
-				}
-				if (config.highlightInventoryClueItems())
-				{
-					cacheClueItems(clue);
-				}
-			}
-		}
-
-		// Highlight for beginner and master clues
 		for (Integer itemID : clueInventoryManager.getTrackedCluesInInventory())
 		{
 			if (itemID == null) continue;

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -391,7 +391,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 			LocalPoint itemLp = new LocalPoint(x, y, wv);
 			WorldPoint itemWp = WorldPoint.fromLocal(client, itemLp);
 			int currentPosForTile = foundPosForWp.getOrDefault(itemWp, 0);
-			if (Clues.isTrackedClueOrTornClue(menuEntries[i].getIdentifier(), clueDetailsPlugin.isDeveloperMode()))
+			if (Clues.isClue(menuEntries[i].getIdentifier(), clueDetailsPlugin.isDeveloperMode()))
 			{
 				mappedEntries.add(new MenuEntryAndPos(menuEntries[i], menuEntries.length - i - 1, currentPosForTile));
 				if (isTakeClue(menuEntries[i])) foundPosForWp.put(itemWp, currentPosForTile + 1);

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -121,7 +121,10 @@ public class ClueDetailsOverlay extends OverlayPanel
 	{
 		if (client.isMenuOpen())
 		{
-			showMenuItem();
+			if (config.showHoverText() && !config.changeClueText())
+			{
+				showMenuItem();
+			}
 		}
 		else
 		{
@@ -190,26 +193,23 @@ public class ClueDetailsOverlay extends OverlayPanel
 
 		List<MenuEntryAndPos> entriesByTile = getEntriesByTile(currentMenuEntries);
 
-		if (config.showHoverText() && !config.changeClueText())
-		{
-			addTooltip(entriesByTile);
-		}
+		addTooltip(entriesByTile);
 	}
 
 	// Using onClientTick for compatability with Ground Items "Collapse ground item menu"
 	@Subscribe
 	public void onClientTick(ClientTick event)
 	{
-		final MenuEntry[] menuEntries = client.getMenuEntries();
-		if (Arrays.stream(menuEntries).noneMatch(this::isTakeClue))
-		{
-			return;
-		}
-
-		List<MenuEntryAndPos> entriesByTile = getEntriesByTile(menuEntries);
-
 		if (config.changeClueText() || config.colorChangeClueText())
 		{
+			final MenuEntry[] menuEntries = client.getMenuEntries();
+			if (Arrays.stream(menuEntries).noneMatch(this::isTakeClue))
+			{
+				return;
+			}
+
+			List<MenuEntryAndPos> entriesByTile = getEntriesByTile(menuEntries);
+
 			changeGroundItemMenu(entriesByTile);
 		}
 	}
@@ -217,16 +217,16 @@ public class ClueDetailsOverlay extends OverlayPanel
 	@Subscribe
 	public void onMenuOpened(MenuOpened event)
 	{
-		MenuEntry[] entries = event.getMenuEntries();
-		if (Arrays.stream(entries).noneMatch(this::isTakeClue))
-		{
-			return;
-		}
-
-		List<MenuEntryAndPos> entriesByTile = getEntriesByTile(entries);
-
 		if (config.changeClueText())
 		{
+			MenuEntry[] entries = event.getMenuEntries();
+			if (Arrays.stream(entries).noneMatch(this::isTakeClue))
+			{
+				return;
+			}
+
+			List<MenuEntryAndPos> entriesByTile = getEntriesByTile(entries);
+
 			addClueSubmenus(entriesByTile);
 		}
 	}
@@ -582,9 +582,9 @@ public class ClueDetailsOverlay extends OverlayPanel
 	public void onItemSpawned(ItemSpawned itemSpawned)
 	{
 		TileItem item = itemSpawned.getItem();
-		Tile tile = itemSpawned.getTile();
 		if (shouldHighlight(item.getId()))
 		{
+			Tile tile = itemSpawned.getTile();
 			notifier.notify(config.markedClueDroppedNotification(), "A highlighted clue has dropped!");
 			tileHighlights.get(tile).add(item.getId());
 		}

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -30,7 +30,6 @@ import java.util.*;
 import javax.inject.Singleton;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
@@ -60,8 +59,6 @@ public class ClueInventoryManager
 	private final ChatboxPanelManager chatboxPanelManager;
 	private final Map<Integer, ClueInstance> trackedCluesInInventory = new HashMap<>();
 	private final Map<Integer, ClueInstance> previousTrackedCluesInInventory = new HashMap<>();
-	@Getter
-	private Clues[] cluesInInventory = new Clues[6];
 
 	// To be initialized to avoid passing around
 	@Setter
@@ -87,9 +84,6 @@ public class ClueInventoryManager
 		// Clear current tracked clues
 		trackedCluesInInventory.clear();
 
-		// Clear current clues in inventory
-		cluesInInventory = new Clues[6];
-
 		Item[] inventoryItems = inventoryContainer.getItems();
 
 		for (Item item : inventoryItems)
@@ -98,13 +92,9 @@ public class ClueInventoryManager
 
 			int itemId = item.getId();
 			
-			if (Clues.isTrackedClueOrTornClue(itemId, clueDetailsPlugin.isDeveloperMode()))
+			if (Clues.isClue(itemId, clueDetailsPlugin.isDeveloperMode()))
 			{
-				checkItemAsBeginnerOrMasterClue(itemId);
-			}
-			else
-			{
-				checkItemAsEasyToMediumClue(itemId);
+				checkItemAsClue(itemId);
 			}
 		}
 
@@ -126,16 +116,7 @@ public class ClueInventoryManager
 		}
 	}
 
-	private void checkItemAsEasyToMediumClue(int id)
-	{
-		Clues clue = Clues.forItemId(id);
-		if (clue != null)
-		{
-			cluesInInventory[clue.getClueTier().getValue()] = clue;
-		}
-	}
-
-	private void checkItemAsBeginnerOrMasterClue(int itemId)
+	private void checkItemAsClue(int itemId)
 	{
 		ClueInstance clueInstance;
 
@@ -289,14 +270,13 @@ public class ClueInventoryManager
 		// Add item highlight menu
 		if (!hasClueName(menuEntry.getTarget()))
 		{
-			if (Arrays.stream(cluesInInventory).allMatch(Objects::isNull) && trackedCluesInInventory.isEmpty()) return;
+			if (trackedCluesInInventory.isEmpty()) return;
 
 			MenuEntry clueDetailsEntry = client.getMenu().createMenuEntry(-1)
 				.setOption("Clue details")
 				.setTarget(menuEntry.getTarget())
 				.setType(MenuAction.RUNELITE);
 			Menu submenu = clueDetailsEntry.createSubMenu();
-			Arrays.stream(cluesInInventory).forEach((clue) -> addHighlightItemMenu(cluePreferenceManager, submenu, clue, itemId, event));
 			trackedCluesInInventory.forEach((id, instance) -> instance.getClueIds().forEach((clueId) -> addHighlightItemMenu(cluePreferenceManager, submenu, Clues.forClueIdFiltered(clueId), itemId, event)));
 			return;
 		}

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1213,7 +1213,7 @@ public class Clues
 
 	public static boolean isTrackedClueOrTornClue(int itemId, boolean isDeveloperMode)
 	{
-		return isClue(itemId, isDeveloperMode) || TRACKED_TORN_CLUE_IDS.contains(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
+		return TRACKED_CLUE_IDS.contains(itemId) || TRACKED_TORN_CLUE_IDS.contains(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
 	}
 
 	public static Collection<Integer> getTrackedClueAndTornClueIds(boolean isDevMode)


### PR DESCRIPTION
- Fixed isTrackedClueOrTornClue which was incorrectly modified, breaking Mark menu option
- ClueDetailsOverlay was slightly optimized to reduce processing when related configs are disabled
  - Users were reporting lag when hovering and right clicking, so hopefully this would make troubleshooting easier
- changeClueText was not applying properly to mixed tracked/untracked piles after the above mentioned isTrackedClueOrTornClue update