### PR TITLE
Cache filteredClues list

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -377,6 +377,16 @@ public class ClueDetailsPlugin extends Plugin
 			infoOverlay.refreshHighlights();
 		}
 
+		if (event.getKey().equals("beginnerDetails")
+			|| event.getKey().equals("easyDetails")
+			|| event.getKey().equals("mediumDetails")
+			|| event.getKey().equals("hardDetails")
+			|| event.getKey().equals("eliteDetails")
+			|| event.getKey().equals("masterDetails"))
+		{
+			Clues.rebuildFilteredCluesCache();
+		}
+
 		if (event.getGroup().equals("clue-details-color")
 			|| event.getGroup().equals("clue-details-items")
 			|| event.getKey().equals("highlightInventoryClueScrolls")

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1076,9 +1076,17 @@ public class Clues
 		ItemID.DAEYALT_ESSENCE
 	);
 
-	public static List<Clues> filteredClues()
-	{
-		if (config == null) return Clues.CLUES;
+	private static List<Clues> cachedFilteredClues = createFilteredCluesCache();
+
+	public static void rebuildFilteredCluesCache() {
+		cachedFilteredClues = createFilteredCluesCache();
+	}
+
+	private static List<Clues> createFilteredCluesCache() {
+		if (config == null)
+		{
+			return Clues.CLUES;
+		}
 
 		List<ClueTier> enabledClues = new ArrayList<>();
 		if (config.beginnerDetails()) enabledClues.add(ClueTier.BEGINNER);
@@ -1102,8 +1110,13 @@ public class Clues
 		if (config.masterDetails()) enabledClues.add(ClueTier.MASTER);
 
 		return Clues.CLUES.stream()
-			.filter(c -> enabledClues.contains(c.getClueTier()))
-			.collect(Collectors.toList());
+				.filter(c -> enabledClues.contains(c.getClueTier()))
+				.collect(Collectors.toList());
+	}
+
+	public static List<Clues> filteredClues()
+	{
+		return cachedFilteredClues;
 	}
 
 	public static Clues forItemId(int itemId)

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1078,11 +1078,13 @@ public class Clues
 
 	private static List<Clues> cachedFilteredClues = createFilteredCluesCache();
 
-	public static void rebuildFilteredCluesCache() {
+	public static void rebuildFilteredCluesCache()
+	{
 		cachedFilteredClues = createFilteredCluesCache();
 	}
 
-	private static List<Clues> createFilteredCluesCache() {
+	private static List<Clues> createFilteredCluesCache()
+	{
 		if (config == null)
 		{
 			return Clues.CLUES;


### PR DESCRIPTION
`Clues.filteredClues` list is being built on each method call and is called a lot in streams based on clue count, leading to noticable performance issues with lots of clues on the ground. This change makes the list cached and rebuilt only on startup and config changes.

Memory allocations before (see the amount of `filteredClues` calls top left, top center, top right)
![image](https://github.com/user-attachments/assets/ee8b2415-1856-40e8-b4ee-456283b03e59)

After the fix (can't be noticed, a very small slice around the middle):
![image](https://github.com/user-attachments/assets/a338c6cd-6b5a-41fd-a0ee-85b71025dd55)
