### PR TITLE
fix: Improvements on ground item tracking

### DIFF
--- a/src/main/java/com/cluedetails/ClueBankManager.java
+++ b/src/main/java/com/cluedetails/ClueBankManager.java
@@ -100,7 +100,7 @@ public class ClueBankManager
 		ClueInstance clueFromBank = cluesInBank.get(trackedClueId);
 		if (clueFromBank == null) return;
 
-		ClueInstance clue = clueInventoryManager.getTrackedClueByClueItemId(trackedClueId);
+		ClueInstance clue = clueInventoryManager.getClueByClueItemId(trackedClueId);
 		clue.setClueIds(clueFromBank.getClueIds());
 
 		cluesInBank.remove(trackedClueId);

--- a/src/main/java/com/cluedetails/ClueDetailsInventoryOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsInventoryOverlay.java
@@ -27,10 +27,8 @@ package com.cluedetails;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.util.Arrays;
 import javax.inject.Inject;
 
-import com.cluedetails.filters.ClueTier;
 import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
@@ -78,7 +76,7 @@ public class ClueDetailsInventoryOverlay extends OverlayPanel
 
 		for (Item item : inventory.getItems())
 		{
-			ClueInstance clueInstance = clueInventoryManager.getTrackedClueByClueItemId(item.getId());
+			ClueInstance clueInstance = clueInventoryManager.getClueByClueItemId(item.getId());
 			if (clueInstance == null || clueInstance.getClueIds().isEmpty()) continue;
 
 			for (Integer clueId : clueInstance.getClueIds())

--- a/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
@@ -24,7 +24,6 @@
  */
 package com.cluedetails;
 
-import com.cluedetails.filters.ClueTier;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.awt.Color;
@@ -99,29 +98,10 @@ public class ClueDetailsItemsOverlay extends WidgetItemOverlay
 		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
 		if (inventory == null || clueInventoryManager == null ) return;
 
-		// Highlight for easy-elite clues
-		for (Clues clue : clueInventoryManager.getCluesInInventory())
-		{
-			if (clue == null) continue;
-
-			if (clue.isEnabled(config))
-			{
-				if (config.highlightInventoryClueScrolls())
-				{
-					cacheClueScrolls(clue);
-				}
-				if (config.highlightInventoryClueItems())
-				{
-					cacheClueItems(clue);
-				}
-			}
-		}
-
-		// Highlight for beginner and master clues
-		for (Integer itemID : clueInventoryManager.getTrackedCluesInInventory())
+		for (Integer itemID : clueInventoryManager.getCluesInInventory())
 		{
 			if (itemID == null) continue;
-			ClueInstance instance = clueInventoryManager.getTrackedClueByClueItemId(itemID);
+			ClueInstance instance = clueInventoryManager.getClueByClueItemId(itemID);
 			if (instance == null) continue;
 
 			instance.getClueIds().forEach((clueId) ->

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -456,7 +456,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 		if (isReadClue(menuEntry))
 		{
 			int scrollID = getScrollID(menuEntry);
-			ClueInstance clueInstance = clueInventoryManager.getTrackedClueByClueItemId(scrollID);
+			ClueInstance clueInstance = clueInventoryManager.getClueByClueItemId(scrollID);
 			if (clueInstance != null && !clueInstance.getClueIds().isEmpty())
 			{
 				return clueInstance.getCombinedClueText(clueDetailsPlugin, configManager, showColor, isFloorText);

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -177,6 +177,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 
 	private void showMenuItem()
 	{
+		if (!(config.showHoverText() && !config.changeClueText())) return;
 		Menu menu = client.getMenu();
 		MenuEntry[] currentMenuEntries = menu.getMenuEntries();
 
@@ -188,47 +189,35 @@ public class ClueDetailsOverlay extends OverlayPanel
 			return;
 		}
 
-		List<MenuEntryAndPos> entriesByTile = getEntriesByTile(currentMenuEntries);
-
-		if (config.showHoverText() && !config.changeClueText())
-		{
-			addTooltip(entriesByTile);
-		}
+		addTooltip(getEntriesByTile(currentMenuEntries));
 	}
 
 	// Using onClientTick for compatability with Ground Items "Collapse ground item menu"
 	@Subscribe
 	public void onClientTick(ClientTick event)
 	{
-		final MenuEntry[] menuEntries = client.getMenuEntries();
+		if (!(config.changeClueText() || config.colorChangeClueText())) return;
+		final MenuEntry[] menuEntries = client.getMenu().getMenuEntries();
 		if (Arrays.stream(menuEntries).noneMatch(this::isTakeClue))
 		{
 			return;
 		}
 
-		List<MenuEntryAndPos> entriesByTile = getEntriesByTile(menuEntries);
-
-		if (config.changeClueText() || config.colorChangeClueText())
-		{
-			changeGroundItemMenu(entriesByTile);
-		}
+		changeGroundItemMenu(getEntriesByTile(client.getMenu().getMenuEntries()));
 	}
 
 	@Subscribe
 	public void onMenuOpened(MenuOpened event)
 	{
+		if (!config.changeClueText()) return;
+
 		MenuEntry[] entries = event.getMenuEntries();
 		if (Arrays.stream(entries).noneMatch(this::isTakeClue))
 		{
 			return;
 		}
 
-		List<MenuEntryAndPos> entriesByTile = getEntriesByTile(entries);
-
-		if (config.changeClueText())
-		{
-			addClueSubmenus(entriesByTile);
-		}
+		addClueSubmenus(getEntriesByTile(entries));
 	}
 
 	private void changeGroundItemMenu(List<MenuEntryAndPos> entriesByTile)
@@ -391,7 +380,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 			LocalPoint itemLp = new LocalPoint(x, y, wv);
 			WorldPoint itemWp = WorldPoint.fromLocal(client, itemLp);
 			int currentPosForTile = foundPosForWp.getOrDefault(itemWp, 0);
-			if (Clues.isTrackedClueOrTornClue(menuEntries[i].getIdentifier(), clueDetailsPlugin.isDeveloperMode()))
+			if (Clues.isClue(menuEntries[i].getIdentifier(), clueDetailsPlugin.isDeveloperMode()))
 			{
 				mappedEntries.add(new MenuEntryAndPos(menuEntries[i], menuEntries.length - i - 1, currentPosForTile));
 				if (isTakeClue(menuEntries[i])) foundPosForWp.put(itemWp, currentPosForTile + 1);
@@ -534,7 +523,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 		int wv = menuEntry.getWorldViewId();
 		LocalPoint itemLp = new LocalPoint(sceneX * SCENE_TO_LOCAL, sceneY * SCENE_TO_LOCAL, wv);
 		WorldPoint itemWp = WorldPoint.fromLocalInstance(client, itemLp);
-		List<ClueInstance> trackedClues = clueGroundManager.getGroundClues().get(itemWp);
+		List<ClueInstance> trackedClues = clueGroundManager.getAllGroundClues().get(itemWp);
 		if (trackedClues == null) return null;
 		if (trackedClues.size() <= entry.getPosOnTile()) return trackedClues.get(entry.getPosOnTile() - 1);
 		return trackedClues.get(entry.getPosOnTile());

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -198,12 +198,13 @@ public class ClueDetailsOverlay extends OverlayPanel
 	{
 		if (!(config.changeClueText() || config.colorChangeClueText())) return;
 		final MenuEntry[] menuEntries = client.getMenu().getMenuEntries();
+
 		if (Arrays.stream(menuEntries).noneMatch(this::isTakeClue))
 		{
 			return;
 		}
 
-		changeGroundItemMenu(getEntriesByTile(client.getMenu().getMenuEntries()));
+		changeGroundItemMenu(getEntriesByTile(menuEntries));
 	}
 
 	@Subscribe
@@ -227,7 +228,6 @@ public class ClueDetailsOverlay extends OverlayPanel
 		{
 			MenuEntry menuEntry = entryAndPos.getMenuEntry();
 			if (!isTakeOrMarkClue(menuEntry)) continue;
-
 			boolean showColor = shouldShowColor(menuEntry);
 			String regex = "(Clue scroll \\(.*?\\)( x [0-9]+)?|Challenge scroll \\(.*?\\)( x [0-9]+)?)";
 			if (clueDetailsPlugin.isDeveloperMode())
@@ -452,28 +452,10 @@ public class ClueDetailsOverlay extends OverlayPanel
 	private String getText(MenuEntryAndPos menuEntryAndPos, boolean showColor, boolean isFloorText)
 	{
 		MenuEntry menuEntry = menuEntryAndPos.getMenuEntry();
-		int scrollID = getScrollID(menuEntry);
-
-		Clues matchingClue = Clues.forItemId(scrollID);
-		if (matchingClue != null)
-		{
-			String text = matchingClue.getDetail(configManager);
-			if (showColor)
-			{
-				Color color = matchingClue.getDetailColor(configManager);
-
-				// Only change floor text color if it's not the default
-				if (!(isFloorText && color == Color.WHITE))
-				{
-					String hexColor = Integer.toHexString(color.getRGB()).substring(2);
-					return "<col=" + hexColor + ">" + text;
-				}
-			}
-			return text;
-		}
 
 		if (isReadClue(menuEntry))
 		{
+			int scrollID = getScrollID(menuEntry);
 			ClueInstance clueInstance = clueInventoryManager.getTrackedClueByClueItemId(scrollID);
 			if (clueInstance != null && !clueInstance.getClueIds().isEmpty())
 			{
@@ -523,8 +505,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 		int wv = menuEntry.getWorldViewId();
 		LocalPoint itemLp = new LocalPoint(sceneX * SCENE_TO_LOCAL, sceneY * SCENE_TO_LOCAL, wv);
 		WorldPoint itemWp = WorldPoint.fromLocalInstance(client, itemLp);
-		List<ClueInstance> trackedClues = clueGroundManager.getAllGroundClues().get(itemWp);
-		if (trackedClues == null) return null;
+		List<ClueInstance> trackedClues = new ArrayList<>(clueGroundManager.getAllGroundCluesOnWp(itemWp));
 		if (trackedClues.size() <= entry.getPosOnTile()) return trackedClues.get(entry.getPosOnTile() - 1);
 		return trackedClues.get(entry.getPosOnTile());
 	}

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -506,7 +506,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 		LocalPoint itemLp = new LocalPoint(sceneX * SCENE_TO_LOCAL, sceneY * SCENE_TO_LOCAL, wv);
 		WorldPoint itemWp = WorldPoint.fromLocalInstance(client, itemLp);
 		List<ClueInstance> trackedClues = new ArrayList<>(clueGroundManager.getAllGroundCluesOnWp(itemWp));
-		if (trackedClues.size() <= entry.getPosOnTile()) return trackedClues.get(entry.getPosOnTile() - 1);
+		if (trackedClues.size() <= entry.getPosOnTile()) return null;
 		return trackedClues.get(entry.getPosOnTile());
 	}
 

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -42,6 +42,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemID;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
@@ -65,7 +66,6 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.RuneScapeProfileChanged;
 import net.runelite.client.game.ItemManager;
-import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
@@ -126,9 +126,6 @@ public class ClueDetailsPlugin extends Plugin
 	@Inject
 	private ConfigManager configManager;
 
-	@Inject
-	private KeyManager keyManager;
-
 	@Getter
 	@Inject
 	private ItemManager itemManager;
@@ -179,6 +176,9 @@ public class ClueDetailsPlugin extends Plugin
 	private NavigationButton navButton;
 
 	private boolean profileChanged;
+
+	@Getter
+	public static int currentTick;
 
 	@Override
 	protected void startUp() throws Exception
@@ -302,9 +302,14 @@ public class ClueDetailsPlugin extends Plugin
 			profileChanged = true;
 		}
 
+		if (event.getGameState() == GameState.LOADING)
+		{
+			clueGroundManager.setLoggedInOccuredThisTick(true);
+		}
+
 		if (event.getGameState() == GameState.LOGGED_IN)
 		{
-			clueGroundManager.clearEasyToEliteClues();
+			clueGroundManager.setLoggedInOccuredThisTick(true);
 			if (profileChanged)
 			{
 				profileChanged = false;
@@ -318,6 +323,12 @@ public class ClueDetailsPlugin extends Plugin
 	public void onRuneScapeProfileChanged(RuneScapeProfileChanged event)
 	{
 		profileChanged = true;
+	}
+
+	@Subscribe
+	public void onClientTick(ClientTick event)
+	{
+		currentTick = client.getTickCount();
 	}
 
 	@Subscribe

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -302,11 +302,15 @@ public class ClueDetailsPlugin extends Plugin
 			profileChanged = true;
 		}
 
-		if (event.getGameState() == GameState.LOGGED_IN && profileChanged)
+		if (event.getGameState() == GameState.LOGGED_IN)
 		{
-			profileChanged = false;
-			clueGroundManager.loadStateFromConfig();
-			clueBankManager.loadStateFromConfig();
+			clueGroundManager.clearEasyToEliteClues();
+			if (profileChanged)
+			{
+				profileChanged = false;
+				clueGroundManager.loadStateFromConfig();
+				clueBankManager.loadStateFromConfig();
+			}
 		}
 	}
 
@@ -456,7 +460,7 @@ public class ClueDetailsPlugin extends Plugin
 	{
 		if (!config.showGroundClueTimers()) return;
 
-		Set<WorldPoint> worldPoints = clueGroundManager.getGroundClues().keySet();
+		Set<WorldPoint> worldPoints = clueGroundManager.getTrackedWorldPoints();
 
 		// Remove timers if worldPoint not managed by clueGroundManager
 		clueGroundTimers.removeIf(timer-> !worldPoints.contains(timer.getWorldPoint()));

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -481,7 +481,7 @@ public class ClueDetailsPlugin extends Plugin
 		{
 			TreeMap<ClueInstance, Integer> clueInstancesWithQuantityAtWp = clueGroundManager.getClueInstancesWithQuantityAtWp(config, worldPoint, client.getTickCount());
 
-			if (clueInstancesWithQuantityAtWp != null)
+			if (clueInstancesWithQuantityAtWp != null && clueInstancesWithQuantityAtWp.firstEntry() != null)
 			{
 				// Find oldest enabled clue instance at the world point
 				ClueInstance oldestEnabledClueInstance = clueInstancesWithQuantityAtWp.firstEntry().getKey();

--- a/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
@@ -67,7 +67,7 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 		}
 
 		// Check if it's a beginner/master clue
-		ClueInstance readClues = clueDetailsPlugin.getClueInventoryManager().getTrackedClueByClueItemId(itemId);
+		ClueInstance readClues = clueDetailsPlugin.getClueInventoryManager().getClueByClueItemId(itemId);
 		if (readClues == null || !readClues.isEnabled(config)) return;
 
 		List<Integer> ids = readClues.getClueIds();
@@ -105,7 +105,7 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 		final ThreeStepCrypticClue threeStepCrypticClue = ThreeStepCrypticClue.forText(text.toString());
 		if (threeStepCrypticClue != null)
 		{
-			threeStepCrypticClue.update(clueDetailsPlugin.getClueInventoryManager().getTrackedCluesInInventory());
+			threeStepCrypticClue.update(clueDetailsPlugin.getClueInventoryManager().getCluesInInventory());
 			clueDetail = threeStepCrypticClue.getDetail(configManager, config);
 			clueDetailColor = Color.WHITE;
 		}

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -91,7 +91,7 @@ public class ClueGroundManager
 			return;
 		}
 
-		ClueInstance inventoryClue = clueDetailsPlugin.getClueInventoryManager().getTrackedClueByClueItemId(item.getId());
+		ClueInstance inventoryClue = clueDetailsPlugin.getClueInventoryManager().getClueByClueItemId(item.getId());
 		// If clue in inventory AND new clue appeared with fresh despawn timer, it must be the inventory item being dropped
 		if (isNewGroundClue(item.getId(), item.getDespawnTime()) && inventoryClue != null)
 		{

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -178,6 +178,7 @@ public class ClueGroundManager
 	public void onGameTick()
 	{
 		loggedInStateOccuredThisTick = false;
+		tileClearedThisTick.clear();
 		currentZone = new Zone(client.getLocalPlayer().getWorldLocation());
 		trackedClues.clearEmptyTiles(currentZone);
 
@@ -351,7 +352,8 @@ public class ClueGroundManager
 		{
 			return Comparator
 				.comparingInt((ClueInstance oc) -> oc.getDespawnTick(client.getTickCount()))
-				.thenComparingLong(ClueInstance::getSequenceNumber).compare(o1, o2);
+				.thenComparingLong(ClueInstance::getSequenceNumber)
+				.compare(o1, o2);
 		}
 	}
 

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -50,6 +50,7 @@ public class ClueGroundManager
 	private Zone currentZone;
 	private WorldPointToClueInstances trackedClues;
 	private boolean loggedInStateOccuredThisTick;
+	private Set<WorldPoint> tileClearedThisTick = new HashSet<>();
 
 	public ClueGroundManager(Client client, ConfigManager configManager, ClueDetailsPlugin clueDetailsPlugin)
 	{
@@ -78,10 +79,10 @@ public class ClueGroundManager
 		if (!Clues.isBeginnerOrMasterClue(item.getId(), clueDetailsPlugin.isDeveloperMode()))
 		{
 			// We don't get items removed when a loading->logged in state occurs. This clears the tile
-			if (loggedInStateOccuredThisTick)
+			if (loggedInStateOccuredThisTick && !tileClearedThisTick.contains(tile.getWorldLocation()))
 			{
+				tileClearedThisTick.add(tile.getWorldLocation());
 				clearEasyToEliteCluesAtWorldPoint(tile.getWorldLocation());
-				loggedInStateOccuredThisTick = false;
 			}
 			ClueInstance clueInstance = new ClueInstance(List.of(), item.getId(), tile.getWorldLocation(), item, client.getTickCount());
 			trackedClues.addClue(clueInstance);

--- a/src/main/java/com/cluedetails/ClueGroundOverlay.java
+++ b/src/main/java/com/cluedetails/ClueGroundOverlay.java
@@ -100,15 +100,15 @@ public class ClueGroundOverlay extends Overlay
 		offsetMap.clear();
 		final LocalPoint localLocation = player.getLocalLocation();
 
-		if (clueGroundManager.getGroundClues().keySet().isEmpty())
+		if (clueGroundManager.getTrackedWorldPoints().isEmpty())
 		{
 			return null;
 		}
 
-		for (WorldPoint wp : clueGroundManager.getGroundClues().keySet())
+		for (WorldPoint wp : clueGroundManager.getTrackedWorldPoints())
 		{
 			// Check if wp in clueGroundManager is within range of the player
-			final LocalPoint groundPoint = LocalPoint.fromWorld(client, wp);
+			final LocalPoint groundPoint = LocalPoint.fromWorld(client.getTopLevelWorldView(), wp);
 
 			if (groundPoint == null || localLocation.distanceTo(groundPoint) > MAX_DISTANCE)
 			{

--- a/src/main/java/com/cluedetails/ClueGroundOverlay.java
+++ b/src/main/java/com/cluedetails/ClueGroundOverlay.java
@@ -29,11 +29,9 @@ import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
@@ -128,10 +126,6 @@ public class ClueGroundOverlay extends Overlay
 			}
 
 			List<Map.Entry<ClueInstance, Integer>> entrySet = new ArrayList<>(clueInstancesWithQuantityAtWp.entrySet());
-
-			// Text added from bottom to top on screen, so reverse order so first element appears on top
-			Collections.reverse(entrySet);
-
 			for (Map.Entry<ClueInstance, Integer> entry : entrySet)
 			{
 				ClueInstance item = entry.getKey();

--- a/src/main/java/com/cluedetails/ClueGroundOverlay.java
+++ b/src/main/java/com/cluedetails/ClueGroundOverlay.java
@@ -28,8 +28,12 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
@@ -123,7 +127,12 @@ public class ClueGroundOverlay extends Overlay
 				continue;
 			}
 
-			for (Map.Entry<ClueInstance, Integer> entry : clueInstancesWithQuantityAtWp.entrySet())
+			List<Map.Entry<ClueInstance, Integer>> entrySet = new ArrayList<>(clueInstancesWithQuantityAtWp.entrySet());
+
+			// Text added from bottom to top on screen, so reverse order so first element appears on top
+			Collections.reverse(entrySet);
+
+			for (Map.Entry<ClueInstance, Integer> entry : entrySet)
 			{
 				ClueInstance item = entry.getKey();
 

--- a/src/main/java/com/cluedetails/ClueGroundSaveDataManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundSaveDataManager.java
@@ -49,7 +49,7 @@ public class ClueGroundSaveDataManager
 		this.gson = gson;
 	}
 
-	public void saveStateToConfig(Client client, Map<WorldPoint, List<ClueInstance>> groundClues)
+	public void saveStateToConfig(Client client, List<ClueInstance> groundClues)
 	{
 		// Serialize groundClues save to config
 		updateData(client, groundClues);
@@ -57,18 +57,14 @@ public class ClueGroundSaveDataManager
 		configManager.setConfiguration(CONFIG_GROUP, GROUND_CLUES_KEY, groundCluesJson);
 	}
 
-	private void updateData(Client client, Map<WorldPoint, List<ClueInstance>> groundClues)
+	private void updateData(Client client, List<ClueInstance> groundClues)
 	{
 		int currentTick = client.getTickCount();
 
 		List<ClueInstanceData> newData = new ArrayList<>();
-		for (Map.Entry<WorldPoint, List<ClueInstance>> entry : groundClues.entrySet())
+		for (ClueInstance groundClue : groundClues)
 		{
-			List<ClueInstance> clueDataList = entry.getValue();
-			for (ClueInstance data : clueDataList)
-			{
-				newData.add(new ClueInstanceData(data, currentTick));
-			}
+			newData.add(new ClueInstanceData(groundClue, currentTick));
 		}
 		clueInstanceData.clear();
 		clueInstanceData.addAll(newData);
@@ -111,7 +107,7 @@ public class ClueGroundSaveDataManager
 			} catch (Exception err)
 			{
 				groundClues.clear();
-				saveStateToConfig(client, groundClues);
+				saveStateToConfig(client, new ArrayList<>());
 			}
 		}
 

--- a/src/main/java/com/cluedetails/ClueGroundTimer.java
+++ b/src/main/java/com/cluedetails/ClueGroundTimer.java
@@ -106,7 +106,7 @@ class ClueGroundTimer extends Timer
 	public boolean cull()
 	{
 		// Remove timers if worldPoint no managed by clueGroundManager
-		Set<WorldPoint> worldPoints = plugin.getClueGroundManager().getGroundClues().keySet();
+		Set<WorldPoint> worldPoints = plugin.getClueGroundManager().getTrackedWorldPoints();
 		if (!worldPoints.contains(worldPoint))
 		{
 			return true;

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -51,7 +51,8 @@ public class ClueInstance
 	private final WorldPoint location; // Null if in inventory
 
 	@Getter
-	private final long sequenceNumber;
+	@Setter
+	private long sequenceNumber;
 
 	@Getter
 	private final Integer timeToDespawnFromDataInTicks;
@@ -321,6 +322,6 @@ public class ClueInstance
 	public String toString()
 	{
 		int despawnTime = getDespawnTick(ClueDetailsPlugin.getCurrentTick());
-		return "ClueInstance{" + "itemId=" + itemId + ", despawnTick=" + despawnTime  + ", worldPoint=" + location + "}";
+		return "ClueInstance{" + "itemId=" + itemId + ", despawnTick=" + despawnTime + ", worldPoint=" + location + ", orderId=" + sequenceNumber + "}";
 	}
 }

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -28,6 +28,7 @@ import com.cluedetails.filters.ClueTier;
 import java.awt.Color;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -78,7 +79,7 @@ public class ClueInstance
 		this.itemId = itemId;
 		this.location = location;
 		this.tileItem = tileItem;
-		this.timeToDespawnFromDataInTicks = currentTick;
+		this.timeToDespawnFromDataInTicks = tileItem.getDespawnTime() - currentTick;
 	}
 
 	public List<Integer> getClueIds()
@@ -109,7 +110,7 @@ public class ClueInstance
 		}
 		return clue.getClueTier();
 	}
-	
+
 	public String getGroundText(ClueDetailsPlugin plugin, ClueDetailsConfig config, ConfigManager configManager, int quantity)
 	{
 		StringBuilder itemStringBuilder = new StringBuilder();
@@ -268,5 +269,46 @@ public class ClueInstance
 			return config.masterDetails();
 		}
 		else return getTier() != null;
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof ClueInstance)) return false;
+		ClueInstance clueInstance = (ClueInstance) o;
+
+		int diff1;
+		int diff2;
+		if (tileItem != null && clueInstance.tileItem != null)
+		{
+			diff1 = tileItem.getDespawnTime();
+			diff2 = clueInstance.tileItem.getDespawnTime();
+		}
+		else if (tileItem == null && clueInstance.tileItem == null)
+		{
+			diff1 = timeToDespawnFromDataInTicks;
+			diff2 = clueInstance.timeToDespawnFromDataInTicks;
+		}
+		else
+		{
+			return false;
+		}
+		// Should this really be considering it equal without consideration for the clueIds?
+		return itemId == clueInstance.itemId && diff1 == diff2 && location.equals(clueInstance.location);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		int despawnTime = tileItem != null ? tileItem.getDespawnTime() : timeToDespawnFromDataInTicks;
+		return Objects.hash(itemId, despawnTime, location);
+	}
+
+	@Override
+	public String toString()
+	{
+		int despawnTime = tileItem != null ? tileItem.getDespawnTime() : timeToDespawnFromDataInTicks;
+		return "ClueInstance{" + "itemId=" + itemId + ", despawnTick=" + despawnTime  + ", worldPoint=" + location + "}";
 	}
 }

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -96,7 +96,7 @@ public class ClueInstance
 
 	public List<Integer> getClueIds()
 	{
-		if (clueIds.isEmpty() && !(itemId == ItemID.CLUE_SCROLL_BEGINNER || itemId == ItemID.CLUE_SCROLL_MASTER))
+		if (clueIds.isEmpty() && !Clues.isBeginnerOrMasterClue(itemId, true))
 		{
 			return Collections.singletonList(itemId);
 		}
@@ -256,7 +256,7 @@ public class ClueInstance
 
 	public boolean isEnabled(ClueDetailsConfig config)
 	{
-		if (itemId == ItemID.CLUE_SCROLL_BEGINNER)
+		if (itemId == ItemID.CLUE_SCROLL_BEGINNER || Clues.DEV_MODE_IDS.contains(itemId))
 		{
 			return config.beginnerDetails();
 		}

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -97,8 +97,8 @@ public class ClueInventoryManager
 			if (item == null) continue;
 
 			int itemId = item.getId();
-			
-			if (Clues.isTrackedClueOrTornClue(itemId, clueDetailsPlugin.isDeveloperMode()))
+
+			if (Clues.isBeginnerOrMasterClue(itemId, clueDetailsPlugin.isDeveloperMode()))
 			{
 				checkItemAsBeginnerOrMasterClue(itemId);
 			}
@@ -309,7 +309,7 @@ public class ClueInventoryManager
 		boolean isMarked = cluePreferenceManager.getHighlightPreference(itemId);
 
 		// Mark Option
-		if (!Clues.isTrackedClueOrTornClue(itemId, clueDetailsPlugin.isDeveloperMode()))
+		if (!Clues.isBeginnerOrMasterClue(itemId, clueDetailsPlugin.isDeveloperMode()))
 		{
 			toggleMarkClue(cluePreferenceManager, panel, itemId, isMarked, name);
 		}
@@ -322,8 +322,7 @@ public class ClueInventoryManager
 		String option = null;
 		String target = null;
 
-		// If beginner or master clue
-		if (Clues.isTrackedClueOrTornClue(itemId, clueDetailsPlugin.isDeveloperMode()))
+		if (Clues.isBeginnerOrMasterClue(itemId, clueDetailsPlugin.isDeveloperMode()))
 		{
 			ClueInstance clueSelected = trackedCluesInInventory.get(itemId);
 			if (clueSelected == null || clueSelected.getClueIds().isEmpty()) return;

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -119,7 +119,6 @@ public class ClueInventoryManager
 				ClueInstance removedClue = previousTrackedCluesInInventory.get(itemId);
 				if (removedClue != null)
 				{
-					clueGroundManager.processPendingGroundCluesFromInventoryChanged(removedClue);
 					clueBankManager.addToRemovedClues(removedClue);
 				}
 			}

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -98,7 +98,7 @@ public class ClueInventoryManager
 
 			int itemId = item.getId();
 
-			if (Clues.isBeginnerOrMasterClue(itemId, clueDetailsPlugin.isDeveloperMode()))
+			if (Clues.isTrackedClueOrTornClue(itemId, clueDetailsPlugin.isDeveloperMode()))
 			{
 				checkItemAsBeginnerOrMasterClue(itemId);
 			}

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -30,7 +30,6 @@ import java.util.*;
 import javax.inject.Singleton;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
@@ -58,10 +57,8 @@ public class ClueInventoryManager
 	private final ClueGroundManager clueGroundManager;
 	private final ClueBankManager clueBankManager;
 	private final ChatboxPanelManager chatboxPanelManager;
-	private final Map<Integer, ClueInstance> trackedCluesInInventory = new HashMap<>();
-	private final Map<Integer, ClueInstance> previousTrackedCluesInInventory = new HashMap<>();
-	@Getter
-	private Clues[] cluesInInventory = new Clues[6];
+	private final Map<Integer, ClueInstance> cluesInInventory = new HashMap<>();
+	private final Map<Integer, ClueInstance> previousCluesInInventory = new HashMap<>();
 
 	// To be initialized to avoid passing around
 	@Setter
@@ -80,15 +77,12 @@ public class ClueInventoryManager
 
 	public void updateInventory(ItemContainer inventoryContainer)
 	{
-		// Copy current tracked clues to previous
-		previousTrackedCluesInInventory.clear();
-		previousTrackedCluesInInventory.putAll(trackedCluesInInventory);
+		// Copy current clues to previous
+		previousCluesInInventory.clear();
+		previousCluesInInventory.putAll(cluesInInventory);
 
-		// Clear current tracked clues
-		trackedCluesInInventory.clear();
-
-		// Clear current clues in inventory
-		cluesInInventory = new Clues[6];
+		// Clear current clues
+		cluesInInventory.clear();
 
 		Item[] inventoryItems = inventoryContainer.getItems();
 
@@ -96,27 +90,18 @@ public class ClueInventoryManager
 		{
 			if (item == null) continue;
 
-			int itemId = item.getId();
-
-			if (Clues.isTrackedClueOrTornClue(itemId, clueDetailsPlugin.isDeveloperMode()))
-			{
-				checkItemAsBeginnerOrMasterClue(itemId);
-			}
-			else
-			{
-				checkItemAsEasyToMediumClue(itemId);
-			}
+			checkItemAsClueInstance(item.getId());
 		}
 
 		clueGroundManager.getDespawnedClueQueueForInventoryCheck().clear();
 
 		// Compare previous and current to find removed clues
-		for (Integer itemId : previousTrackedCluesInInventory.keySet())
+		for (Integer itemId : previousCluesInInventory.keySet())
 		{
-			if (!trackedCluesInInventory.containsKey(itemId) || trackedCluesInInventory.get(itemId) != previousTrackedCluesInInventory.get(itemId))
+			if (!cluesInInventory.containsKey(itemId) || cluesInInventory.get(itemId) != previousCluesInInventory.get(itemId))
 			{
 				// Clue was removed from inventory (possibly dropped)
-				ClueInstance removedClue = previousTrackedCluesInInventory.get(itemId);
+				ClueInstance removedClue = previousCluesInInventory.get(itemId);
 				if (removedClue != null)
 				{
 					clueBankManager.addToRemovedClues(removedClue);
@@ -125,16 +110,7 @@ public class ClueInventoryManager
 		}
 	}
 
-	private void checkItemAsEasyToMediumClue(int id)
-	{
-		Clues clue = Clues.forItemId(id);
-		if (clue != null)
-		{
-			cluesInInventory[clue.getClueTier().getValue()] = clue;
-		}
-	}
-
-	private void checkItemAsBeginnerOrMasterClue(int itemId)
+	private void checkItemAsClueInstance(int itemId)
 	{
 		ClueInstance clueInstance;
 
@@ -144,21 +120,21 @@ public class ClueInventoryManager
 			.findFirst();
 		if (clueFromFloorInInv.isPresent())
 		{
-			trackedCluesInInventory.put(itemId, new ClueInstance(clueFromFloorInInv.get().getClueIds(), itemId));
+			cluesInInventory.put(itemId, new ClueInstance(clueFromFloorInInv.get().getClueIds(), itemId));
 			return;
 		}
 
 		// If clue is already in previous, keep the same ClueInstance
 		// This check is after the floor check as you could drop and pick up a clue in the same tick
-		clueInstance = previousTrackedCluesInInventory.get(itemId);
+		clueInstance = previousCluesInInventory.get(itemId);
 		if (clueInstance != null && Clues.isClue(clueInstance.getItemId(), clueDetailsPlugin.isDeveloperMode()))
 		{
-			trackedCluesInInventory.put(itemId, clueInstance);
+			cluesInInventory.put(itemId, clueInstance);
 		}
 		else
 		{
 			clueInstance = new ClueInstance(new ArrayList<>(), itemId);
-			trackedCluesInInventory.put(itemId, clueInstance);
+			cluesInInventory.put(itemId, clueInstance);
 		}
 	}
 
@@ -172,7 +148,7 @@ public class ClueInventoryManager
 			for (Integer devModeId : Clues.DEV_MODE_IDS)
 			{
 				int randomTestId = (int) (Math.random() * 20);
-				trackedCluesInInventory.put(devModeId, new ClueInstance(List.of(randomTestId), devModeId));
+				cluesInInventory.put(devModeId, new ClueInstance(List.of(randomTestId), devModeId));
 			}
 		}
 
@@ -191,10 +167,10 @@ public class ClueInventoryManager
 
 		if (clueIds.get(0) == null) return;
 
-		Set<Integer> itemIDs = trackedCluesInInventory.keySet();
+		Set<Integer> itemIDs = cluesInInventory.keySet();
 		for (Integer itemID : itemIDs)
 		{
-			ClueInstance clueInstance = trackedCluesInInventory.get(itemID);
+			ClueInstance clueInstance = cluesInInventory.get(itemID);
 			// Check that at least one part of the clue text matches the clue tier we're looking at
 			if (clueInstance == null) continue;
 			Clues clueInfo = Clues.forClueIdFiltered(clueIds.get(0));
@@ -214,24 +190,19 @@ public class ClueInventoryManager
 		clueIds.add(Clues.forInterfaceIdGetId(interfaceId));
 
 		// Assume can only be beginner for now
-		ClueInstance beginnerClueInInv = trackedCluesInInventory.get(ItemID.CLUE_SCROLL_BEGINNER);
+		ClueInstance beginnerClueInInv = cluesInInventory.get(ItemID.CLUE_SCROLL_BEGINNER);
 		if (beginnerClueInInv == null) return;
 		beginnerClueInInv.setClueIds(clueIds);
 	}
 
-	public Set<Integer> getTrackedCluesInInventory()
+	public Set<Integer> getCluesInInventory()
 	{
-		return trackedCluesInInventory.keySet();
+		return cluesInInventory.keySet();
 	}
 
-	public ClueInstance getTrackedClueByClueItemId(Integer clueItemID)
+	public ClueInstance getClueByClueItemId(Integer clueItemID)
 	{
-		return trackedCluesInInventory.get(clueItemID);
-	}
-
-	public boolean hasTrackedClues()
-	{
-		return !trackedCluesInInventory.isEmpty();
+		return cluesInInventory.get(clueItemID);
 	}
 
 	public void onMenuEntryAdded(MenuEntryAdded event, CluePreferenceManager cluePreferenceManager, ClueDetailsParentPanel panel)
@@ -288,15 +259,14 @@ public class ClueInventoryManager
 		// Add item highlight menu
 		if (!hasClueName(menuEntry.getTarget()))
 		{
-			if (Arrays.stream(cluesInInventory).allMatch(Objects::isNull) && trackedCluesInInventory.isEmpty()) return;
+			if (cluesInInventory.isEmpty()) return;
 
 			MenuEntry clueDetailsEntry = client.getMenu().createMenuEntry(-1)
 				.setOption("Clue details")
 				.setTarget(menuEntry.getTarget())
 				.setType(MenuAction.RUNELITE);
 			Menu submenu = clueDetailsEntry.createSubMenu();
-			Arrays.stream(cluesInInventory).forEach((clue) -> addHighlightItemMenu(cluePreferenceManager, submenu, clue, itemId, event));
-			trackedCluesInInventory.forEach((id, instance) -> instance.getClueIds().forEach((clueId) -> addHighlightItemMenu(cluePreferenceManager, submenu, Clues.forClueIdFiltered(clueId), itemId, event)));
+			cluesInInventory.forEach((id, instance) -> instance.getClueIds().forEach((clueId) -> addHighlightItemMenu(cluePreferenceManager, submenu, Clues.forClueIdFiltered(clueId), itemId, event)));
 			return;
 		}
 
@@ -324,7 +294,7 @@ public class ClueInventoryManager
 
 		if (Clues.isBeginnerOrMasterClue(itemId, clueDetailsPlugin.isDeveloperMode()))
 		{
-			ClueInstance clueSelected = trackedCluesInInventory.get(itemId);
+			ClueInstance clueSelected = cluesInInventory.get(itemId);
 			if (clueSelected == null || clueSelected.getClueIds().isEmpty()) return;
 
 			clueIds.addAll(clueSelected.getClueIds());
@@ -466,14 +436,14 @@ public class ClueInventoryManager
 		if (isNewBeginnerClue(chatDialogClueItemWidget)
 			|| (isUriBeginnerClue(headModelWidget) && isUriStandardDialogue(npcChatWidget)))
 		{
-			ClueInstance clue = trackedCluesInInventory.get(ItemID.CLUE_SCROLL_BEGINNER);
+			ClueInstance clue = cluesInInventory.get(ItemID.CLUE_SCROLL_BEGINNER);
 			if (clue == null) return;
 			clue.setClueIds(List.of());
 		}
 		else if (isNewMasterClue(chatDialogClueItemWidget)
 			|| (isUriMasterClue(headModelWidget) && isUriStandardDialogue(npcChatWidget)))
 		{
-			ClueInstance clue =  trackedCluesInInventory.get(ItemID.CLUE_SCROLL_MASTER);
+			ClueInstance clue =  cluesInInventory.get(ItemID.CLUE_SCROLL_MASTER);
 			if (clue == null) return;
 			clue.setClueIds(List.of());
 		}

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1231,6 +1231,11 @@ public class Clues
 		return TRACKED_CLUE_IDS.contains(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
 	}
 
+	public static boolean isTrackedClueOrTornClue(int itemId, boolean isDeveloperMode)
+	{
+		return TRACKED_CLUE_IDS.contains(itemId) || TRACKED_TORN_CLUE_IDS.contains(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
+	}
+
 	public static Collection<Integer> getTrackedClueAndTornClueIds(boolean isDevMode)
 	{
 		Collection<Integer> allIds = new ArrayList<>();

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1231,11 +1231,6 @@ public class Clues
 		return TRACKED_CLUE_IDS.contains(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
 	}
 
-	public static boolean isTrackedClueOrTornClue(int itemId, boolean isDeveloperMode)
-	{
-		return isClue(itemId, isDeveloperMode) || TRACKED_TORN_CLUE_IDS.contains(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
-	}
-
 	public static Collection<Integer> getTrackedClueAndTornClueIds(boolean isDevMode)
 	{
 		Collection<Integer> allIds = new ArrayList<>();

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1226,9 +1226,9 @@ public class Clues
 		return filteredClues().stream().anyMatch((clue) -> clue.getItemID() == itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
 	}
 
-	public static boolean isBeginnerOrMasterClue(int itemId)
+	public static boolean isBeginnerOrMasterClue(int itemId, boolean isDeveloperMode)
 	{
-		return TRACKED_CLUE_IDS.contains(itemId);
+		return TRACKED_CLUE_IDS.contains(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
 	}
 
 	public static boolean isTrackedClueOrTornClue(int itemId, boolean isDeveloperMode)

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1226,6 +1226,11 @@ public class Clues
 		return filteredClues().stream().anyMatch((clue) -> clue.getItemID() == itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));
 	}
 
+	public static boolean isBeginnerOrMasterClue(int itemId)
+	{
+		return TRACKED_CLUE_IDS.contains(itemId);
+	}
+
 	public static boolean isTrackedClueOrTornClue(int itemId, boolean isDeveloperMode)
 	{
 		return isClue(itemId, isDeveloperMode) || TRACKED_TORN_CLUE_IDS.contains(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));

--- a/src/main/java/com/cluedetails/WorldPointToClueInstances.java
+++ b/src/main/java/com/cluedetails/WorldPointToClueInstances.java
@@ -81,6 +81,11 @@ public class WorldPointToClueInstances
 				cluesByWorldPoint.computeIfAbsent(wp, k -> new TreeSet<>(clueComparator)).add(clueInstance);
 			}
 		}
+
+		if (cluesByWorldPoint.get(wp).isEmpty())
+		{
+			cluesByWorldPoint.remove(wp);
+		}
 	}
 
 	public List<ClueInstance> getAllClues()

--- a/src/main/java/com/cluedetails/WorldPointToClueInstances.java
+++ b/src/main/java/com/cluedetails/WorldPointToClueInstances.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2025, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.cluedetails;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import net.runelite.api.Client;
+import net.runelite.api.Tile;
+import net.runelite.api.WorldView;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+
+public class WorldPointToClueInstances
+{
+	private final Client client;
+	private final ClueDetailsPlugin clueDetailsPlugin;
+	private final Comparator<ClueInstance> clueComparator;
+
+	private final Map<WorldPoint, SortedSet<ClueInstance>> cluesByWorldPoint = new HashMap<>();
+	private final Map<WorldPoint, List<ClueInstance>> groundCluesBeginnerAndMaster = new HashMap<>();
+	private final Map<WorldPoint, List<ClueInstance>> groundCluesEasyToElite = new HashMap<>();
+
+	public WorldPointToClueInstances(Client client, ClueDetailsPlugin clueDetailsPlugin)
+	{
+		this.client = client;
+		this.clueDetailsPlugin = clueDetailsPlugin;
+
+		clueComparator = Comparator
+			.comparingInt((ClueInstance oc) -> oc.getDespawnTick(client.getTickCount()))
+			.thenComparingLong(ClueInstance::getSequenceNumber);
+	}
+
+	private SortedSet<ClueInstance> getOrCreateSet(Map<WorldPoint, SortedSet<ClueInstance>> clueStore, WorldPoint wp)
+	{
+		return clueStore.computeIfAbsent(wp, k -> new TreeSet<>(clueComparator));
+	}
+
+	public List<ClueInstance> getAllClues()
+	{
+		SortedSet<ClueInstance> allClues = new TreeSet<>(clueComparator);
+		cluesByWorldPoint.values().forEach(allClues::addAll);
+		return new ArrayList<>(allClues);
+	}
+
+	public SortedSet<ClueInstance> getAllCluesAtWorldPoint(WorldPoint wp)
+	{
+		return cluesByWorldPoint.getOrDefault(wp, Collections.emptySortedSet());
+	}
+
+	public List<ClueInstance> getBeginnerAndMasterCluesAtWorldPoint(WorldPoint wp)
+	{
+		return new ArrayList<>(groundCluesBeginnerAndMaster.getOrDefault(wp, new ArrayList<>()));
+	}
+
+	public void addClue(ClueInstance clueInstance)
+	{
+		getOrCreateSet(cluesByWorldPoint, clueInstance.getLocation()).add(clueInstance);
+		if (Clues.isBeginnerOrMasterClue(clueInstance.getItemId(), clueDetailsPlugin.isDeveloperMode()))
+		{
+			addBeginnerMasterClue(clueInstance);
+		}
+		else if (Clues.isClue(clueInstance.getItemId(), clueDetailsPlugin.isDeveloperMode()))
+		{
+			addEasyToEliteClue(clueInstance);
+		}
+	}
+
+	public void removeClue(ClueInstance clueInstance)
+	{
+		ClueInstance instanceRemoved = null;
+		if (Clues.isBeginnerOrMasterClue(clueInstance.getItemId(), clueDetailsPlugin.isDeveloperMode()))
+		{
+			instanceRemoved = removeBeginnerMasterClue(clueInstance);
+		}
+		else if (Clues.isClue(clueInstance.getItemId(), clueDetailsPlugin.isDeveloperMode()))
+		{
+			instanceRemoved = removeEasyToEliteClue(clueInstance);
+		}
+
+		if (instanceRemoved == null) return;
+		SortedSet<ClueInstance> set = cluesByWorldPoint.get(instanceRemoved.getLocation());
+		if (set != null)
+		{
+			set.remove(instanceRemoved);
+			if (set.isEmpty())
+			{
+				cluesByWorldPoint.remove(instanceRemoved.getLocation());
+			}
+		}
+	}
+
+	private void addBeginnerMasterClue(ClueInstance clue)
+	{
+		groundCluesBeginnerAndMaster.computeIfAbsent(clue.getLocation(), k -> new ArrayList<>()).add(clue);
+	}
+
+	private void addEasyToEliteClue(ClueInstance clueInstance)
+	{
+		groundCluesEasyToElite.computeIfAbsent(clueInstance.getLocation(), k -> new ArrayList<>()).add(clueInstance);
+	}
+
+	private ClueInstance removeBeginnerMasterClue(ClueInstance clueInstance)
+	{
+		List<ClueInstance> list = groundCluesBeginnerAndMaster.get(clueInstance.getLocation());
+		if (list != null)
+		{
+			int index = list.indexOf(clueInstance);
+			ClueInstance instanceRemoved = index != -1 ? list.remove(index) : null;
+
+			if (list.isEmpty())
+			{
+				groundCluesBeginnerAndMaster.remove(clueInstance.getLocation());
+			}
+
+			return instanceRemoved;
+		}
+
+		return null;
+	}
+
+	private ClueInstance removeEasyToEliteClue(ClueInstance clueInstance)
+	{
+		List<ClueInstance> list = groundCluesEasyToElite.get(clueInstance.getLocation());
+		if (list != null)
+		{
+			int index = list.indexOf(clueInstance);
+			ClueInstance instanceRemoved = index != -1 ? list.remove(index) : null;
+
+			if (groundCluesEasyToElite.get(clueInstance.getLocation()) != null && groundCluesEasyToElite.get(clueInstance.getLocation()).isEmpty())
+			{
+				groundCluesEasyToElite.remove(clueInstance.getLocation());
+			}
+
+			return instanceRemoved;
+		}
+
+		return null;
+	}
+
+	public void clearEasyToEliteCluesAtWorldPoint(WorldPoint wp)
+	{
+		List<ClueInstance> clues = groundCluesEasyToElite.get(wp);
+		if (clues == null) return;
+		new ArrayList<>(clues).forEach(this::removeClue);
+	}
+
+	public void clearBeginnerAndMasterCluesAtWorldPoint(WorldPoint wp)
+	{
+		List<ClueInstance> clues = groundCluesBeginnerAndMaster.get(wp);
+		if (clues == null) return;
+		new ArrayList<>(clues).forEach(this::removeClue);
+	}
+
+	public void clearEmptyTiles(Zone currentZone)
+	{
+		for (ClueInstance clueInstance : getAllClues())
+		{
+			Tile tile = getTileAtWorldPoint(clueInstance.getLocation());
+			if (tile == null) continue;
+
+			Zone clueZone = new Zone(tile.getWorldLocation());
+			// Item won't have potentially spawned if too far, so don't remove
+			int zonesDistance = clueZone.maxDistanceTo(currentZone);
+			if (zonesDistance >= 4) continue;
+			if (tile.getGroundItems() == null || tile.getGroundItems().isEmpty())
+			{
+				removeClue(clueInstance);
+			}
+		}
+	}
+
+	public void clearAllClues()
+	{
+		groundCluesEasyToElite.clear();
+		groundCluesBeginnerAndMaster.clear();
+		cluesByWorldPoint.clear();
+	}
+
+	public void removeDespawnedClues()
+	{
+		for (ClueInstance clueInstance : getAllClues())
+		{
+			if (clueInstance.getDespawnTick(client.getTickCount()) <= client.getTickCount())
+			{
+				removeClue(clueInstance);
+			}
+		}
+	}
+
+	public Set<WorldPoint> getAllTrackedWorldPoints()
+	{
+		return cluesByWorldPoint.keySet();
+	}
+
+	public Tile getTileAtWorldPoint(WorldPoint tileWp)
+	{
+		WorldView worldView = client.getTopLevelWorldView();
+		LocalPoint tileLp = LocalPoint.fromWorld(worldView, tileWp);
+		if (tileLp == null)
+		{
+			return null;
+		}
+		return worldView.getScene().getTiles()[tileWp.getPlane()][tileLp.getSceneX()][tileLp.getSceneY()];
+	}
+}

--- a/src/main/java/com/cluedetails/WorldPointToClueInstances.java
+++ b/src/main/java/com/cluedetails/WorldPointToClueInstances.java
@@ -61,7 +61,10 @@ public class WorldPointToClueInstances
 
 	private void createGroupedSet(WorldPoint wp)
 	{
-		cluesByWorldPoint.get(wp).clear();
+		if (cluesByWorldPoint.get(wp) != null)
+		{
+			cluesByWorldPoint.get(wp).clear();
+		}
 		for (ClueInstance clueInstance : groundCluesBeginnerAndMaster.get(wp))
 		{
 			cluesByWorldPoint.computeIfAbsent(wp, k -> new TreeSet<>(clueComparator)).add(clueInstance);

--- a/src/main/java/com/cluedetails/WorldPointToClueInstances.java
+++ b/src/main/java/com/cluedetails/WorldPointToClueInstances.java
@@ -65,14 +65,21 @@ public class WorldPointToClueInstances
 		{
 			cluesByWorldPoint.get(wp).clear();
 		}
-		for (ClueInstance clueInstance : groundCluesBeginnerAndMaster.get(wp))
+
+		if (groundCluesBeginnerAndMaster.get(wp) != null)
 		{
-			cluesByWorldPoint.computeIfAbsent(wp, k -> new TreeSet<>(clueComparator)).add(clueInstance);
+			for (ClueInstance clueInstance : groundCluesBeginnerAndMaster.get(wp))
+			{
+				cluesByWorldPoint.computeIfAbsent(wp, k -> new TreeSet<>(clueComparator)).add(clueInstance);
+			}
 		}
 
-		for (ClueInstance clueInstance : groundCluesEasyToElite.get(wp))
+		if (groundCluesEasyToElite.get(wp) != null)
 		{
-			cluesByWorldPoint.computeIfAbsent(wp, k -> new TreeSet<>(clueComparator)).add(clueInstance);
+			for (ClueInstance clueInstance : groundCluesEasyToElite.get(wp))
+			{
+				cluesByWorldPoint.computeIfAbsent(wp, k -> new TreeSet<>(clueComparator)).add(clueInstance);
+			}
 		}
 	}
 

--- a/src/main/java/com/cluedetails/WorldPointToClueInstances.java
+++ b/src/main/java/com/cluedetails/WorldPointToClueInstances.java
@@ -61,20 +61,16 @@ public class WorldPointToClueInstances
 
 	private void createGroupedSet(WorldPoint wp)
 	{
-		cluesByWorldPoint.clear();
-		groundCluesBeginnerAndMaster.forEach(((worldPoint, clueInstances) -> {
-			for (ClueInstance clueInstance : clueInstances)
-			{
-				cluesByWorldPoint.computeIfAbsent(wp, k -> new TreeSet<>(clueComparator)).add(clueInstance);
-			}
-		}));
+		cluesByWorldPoint.get(wp).clear();
+		for (ClueInstance clueInstance : groundCluesBeginnerAndMaster.get(wp))
+		{
+			cluesByWorldPoint.computeIfAbsent(wp, k -> new TreeSet<>(clueComparator)).add(clueInstance);
+		}
 
-		groundCluesEasyToElite.forEach(((worldPoint, clueInstances) -> {
-			for (ClueInstance clueInstance : clueInstances)
-			{
-				cluesByWorldPoint.computeIfAbsent(wp, k -> new TreeSet<>(clueComparator)).add(clueInstance);
-			}
-		}));
+		for (ClueInstance clueInstance : groundCluesEasyToElite.get(wp))
+		{
+			cluesByWorldPoint.computeIfAbsent(wp, k -> new TreeSet<>(clueComparator)).add(clueInstance);
+		}
 	}
 
 	public List<ClueInstance> getAllClues()

--- a/src/main/java/com/cluedetails/WorldPointToClueInstances.java
+++ b/src/main/java/com/cluedetails/WorldPointToClueInstances.java
@@ -55,8 +55,8 @@ public class WorldPointToClueInstances
 		this.clueDetailsPlugin = clueDetailsPlugin;
 
 		clueComparator = Comparator
-			.comparingInt((ClueInstance oc) -> oc.getDespawnTick(client.getTickCount()))
-			.thenComparingLong(ClueInstance::getSequenceNumber);
+			.comparingLong(ClueInstance::getSequenceNumber)
+			.thenComparingInt((ClueInstance oc) -> oc.getDespawnTick(client.getTickCount()));
 	}
 
 	private SortedSet<ClueInstance> getOrCreateSet(Map<WorldPoint, SortedSet<ClueInstance>> clueStore, WorldPoint wp)


### PR DESCRIPTION
This PR makes a few changes:

**Improved Clue Dropping Detection**

Firstly, I realised that when an item is dropped from the inventory, the onItemSpawned event will occur before the item dissapearing from the inventory. This means that if a clue is in the player's inventory and the same clue appears on the floor, and the dropped clue has the max despawn time, it must be from the inventory as you can't get drops whilst having the same tier clue.

This means we don't need to keep a track of appearing clues to later compare to the inventory state, and instead can just copy a ClueInstance from inventory when a clue appears in onItemSpawned.

Possible predicted issue: I'm unsure how this works when it comes to poor internet connections. I'd hope it still keeps the same execution order, but it possibly won't.

**Separated Out Logic For Easy-Elite Clues and Beginner/Master Clues**

As easy to elite clues don't require tracking outside of memory of the last state of a tile in terms of itemIDs and their despawnTicks, they're quite different to beginner to master clues where it's important we are able to keep an exact track of which clue is which in terms of metadata (clueIDs).

Given that, I've added `WorldPointToClueInstances`, which contains three collections, one for easy-elite, one for beginner/master, and one to contain both but organised by despawnTick. This means that we can clear a tile of easy-elite clues when we re-enter a scene and simply create new ClueInstances for them as they spawn back in, rather than the more complex despawnTick mappings and such we do for beginners and masters.

**Better Same Despawn Tick Ordering Detection**

I've included an incrementing count inside each ClueInstance, which can be used for determing drop order of clues dropped on the same tick. The only way I could think of where two clues of the same tier could be dropped on the same tick was to drop a clue on the tile of a dying monster on the same tick it dies, and it drop a clue. Given that, a combination of ItemID, despawnTick, and unique incrementing ID should ensure we keep track of clues as they're represented on tiles.

**Looping Removal**

Overall, I've tried my best to remove iteration where it's unnecessary, and implemented a equals and hash method for ClueInstance which is used for getting. I've created more collections to make it faster to query them each for the relevant information rather than using one object and having to use non-keys to find specific ClueInstances.

**Notes**

I think there's still quite a lot to be further optimised, notably for how many comparisons and object constructions and such are done for overlays which run every clientTick or frame. Preferably we should look to pre-construct as much as we can, so that only on specific change events we update once an object, which then is queried simply for a string to show, or a number or w/e.