### PR TITLE
Cache clues in maps instead of a list for faster lookups

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -198,6 +198,7 @@ public class ClueDetailsPlugin extends Plugin
 		eventBus.register(itemsOverlay);
 
 		Clues.setConfig(config);
+		Clues.rebuildFilteredCluesCache();
 		ClueInventoryManager.setConfig(config);
 
 		cluePreferenceManager = new CluePreferenceManager(this, configManager);

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -1083,6 +1082,7 @@ public class Clues
 
 	private static Map<Integer, List<Clues>> itemIdClueCache = new HashMap<>();
 	private static Map<Integer, Clues> clueIdClueCache = new HashMap<>();
+	private static Map<Integer, Clues> unfilteredClueCache = new HashMap<>();
 
 	public static void rebuildFilteredCluesCache()
 	{
@@ -1097,6 +1097,10 @@ public class Clues
 				.collect(Collectors.groupingBy(Clues::getItemID));
 
 		clueIdClueCache = enabledClues
+				.stream()
+				.collect(Collectors.toMap(Clues::getClueID, clue -> clue));
+
+		unfilteredClueCache = Clues.CLUES
 				.stream()
 				.collect(Collectors.toMap(Clues::getClueID, clue -> clue));
 	}
@@ -1144,7 +1148,7 @@ public class Clues
 
 	public static Clues forClueId(int clueId)
 	{
-		return clueIdClueCache.get(clueId);
+		return unfilteredClueCache.get(clueId);
 	}
 
 	public static Clues forClueIdFiltered(int clueId)

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1183,12 +1183,9 @@ public class Clues
 	public static Integer forInterfaceIdGetId(int interfaceId)
 	{
 		List<Clues> clues = itemIdClueCache.get(interfaceId);
-		for (Clues clue : clues)
+		if (!clues.isEmpty())
 		{
-			// Only check beginner map clues
-			if (clue != null && clue.clueID >= 21 && clue.clueID < 26) {
-				return clue.clueID;
-			}
+			return clues.get(0).clueID;
 		}
 		return null;
 	}


### PR DESCRIPTION
@TheLope noticed in https://github.com/Zoinkwiz/clue-details/pull/117#pullrequestreview-2708812499 that teleport lag was not completely fixed with master clues and with further inspection I realized that clues were constantly being searched from the cache list with loops where we could instead use maps with clue id/item id as keys.

Method calls from teleporting to crafting guild with ~60 "master clues" and away about 5 times:

Before:
![image](https://github.com/user-attachments/assets/87e017de-7ff8-4dd4-8b92-a03fe8175dc4)

After:
![image](https://github.com/user-attachments/assets/46f869ef-bfad-42c0-af67-9bf4ad950660)

