### PR TITLE
fix/inventory-overlay

### DIFF
--- a/src/main/java/com/cluedetails/ClueBankManager.java
+++ b/src/main/java/com/cluedetails/ClueBankManager.java
@@ -100,7 +100,7 @@ public class ClueBankManager
 		ClueInstance clueFromBank = cluesInBank.get(trackedClueId);
 		if (clueFromBank == null) return;
 
-		ClueInstance clue = clueInventoryManager.getTrackedClueByClueItemId(trackedClueId);
+		ClueInstance clue = clueInventoryManager.getClueByClueItemId(trackedClueId);
 		clue.setClueIds(clueFromBank.getClueIds());
 
 		cluesInBank.remove(trackedClueId);

--- a/src/main/java/com/cluedetails/ClueDetailsInventoryOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsInventoryOverlay.java
@@ -27,10 +27,8 @@ package com.cluedetails;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.util.Arrays;
 import javax.inject.Inject;
 
-import com.cluedetails.filters.ClueTier;
 import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
@@ -78,7 +76,7 @@ public class ClueDetailsInventoryOverlay extends OverlayPanel
 
 		for (Item item : inventory.getItems())
 		{
-			ClueInstance clueInstance = clueInventoryManager.getTrackedClueByClueItemId(item.getId());
+			ClueInstance clueInstance = clueInventoryManager.getClueByClueItemId(item.getId());
 			if (clueInstance == null || clueInstance.getClueIds().isEmpty()) continue;
 
 			for (Integer clueId : clueInstance.getClueIds())

--- a/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
@@ -24,7 +24,6 @@
  */
 package com.cluedetails;
 
-import com.cluedetails.filters.ClueTier;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.awt.Color;
@@ -99,29 +98,10 @@ public class ClueDetailsItemsOverlay extends WidgetItemOverlay
 		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
 		if (inventory == null || clueInventoryManager == null ) return;
 
-		// Highlight for easy-elite clues
-		for (Clues clue : clueInventoryManager.getCluesInInventory())
-		{
-			if (clue == null) continue;
-
-			if (clue.isEnabled(config))
-			{
-				if (config.highlightInventoryClueScrolls())
-				{
-					cacheClueScrolls(clue);
-				}
-				if (config.highlightInventoryClueItems())
-				{
-					cacheClueItems(clue);
-				}
-			}
-		}
-
-		// Highlight for beginner and master clues
-		for (Integer itemID : clueInventoryManager.getTrackedCluesInInventory())
+		for (Integer itemID : clueInventoryManager.getCluesInInventory())
 		{
 			if (itemID == null) continue;
-			ClueInstance instance = clueInventoryManager.getTrackedClueByClueItemId(itemID);
+			ClueInstance instance = clueInventoryManager.getClueByClueItemId(itemID);
 			if (instance == null) continue;
 
 			instance.getClueIds().forEach((clueId) ->

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -456,7 +456,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 		if (isReadClue(menuEntry))
 		{
 			int scrollID = getScrollID(menuEntry);
-			ClueInstance clueInstance = clueInventoryManager.getTrackedClueByClueItemId(scrollID);
+			ClueInstance clueInstance = clueInventoryManager.getClueByClueItemId(scrollID);
 			if (clueInstance != null && !clueInstance.getClueIds().isEmpty())
 			{
 				return clueInstance.getCombinedClueText(clueDetailsPlugin, configManager, showColor, isFloorText);

--- a/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
@@ -67,7 +67,7 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 		}
 
 		// Check if it's a beginner/master clue
-		ClueInstance readClues = clueDetailsPlugin.getClueInventoryManager().getTrackedClueByClueItemId(itemId);
+		ClueInstance readClues = clueDetailsPlugin.getClueInventoryManager().getClueByClueItemId(itemId);
 		if (readClues == null || !readClues.isEnabled(config)) return;
 
 		List<Integer> ids = readClues.getClueIds();
@@ -105,7 +105,7 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 		final ThreeStepCrypticClue threeStepCrypticClue = ThreeStepCrypticClue.forText(text.toString());
 		if (threeStepCrypticClue != null)
 		{
-			threeStepCrypticClue.update(clueDetailsPlugin.getClueInventoryManager().getTrackedCluesInInventory());
+			threeStepCrypticClue.update(clueDetailsPlugin.getClueInventoryManager().getCluesInInventory());
 			clueDetail = threeStepCrypticClue.getDetail(configManager, config);
 			clueDetailColor = Color.WHITE;
 		}

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -89,7 +89,7 @@ public class ClueGroundManager
 			return;
 		}
 
-		ClueInstance inventoryClue = clueDetailsPlugin.getClueInventoryManager().getTrackedClueByClueItemId(item.getId());
+		ClueInstance inventoryClue = clueDetailsPlugin.getClueInventoryManager().getClueByClueItemId(item.getId());
 		// If clue in inventory AND new clue appeared with fresh despawn timer, it must be the inventory item being dropped
 		if (isNewGroundClue(item.getId(), item.getDespawnTime()) && inventoryClue != null)
 		{

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -30,7 +30,6 @@ import java.util.*;
 import javax.inject.Singleton;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
@@ -58,10 +57,8 @@ public class ClueInventoryManager
 	private final ClueGroundManager clueGroundManager;
 	private final ClueBankManager clueBankManager;
 	private final ChatboxPanelManager chatboxPanelManager;
-	private final Map<Integer, ClueInstance> trackedCluesInInventory = new HashMap<>();
-	private final Map<Integer, ClueInstance> previousTrackedCluesInInventory = new HashMap<>();
-	@Getter
-	private Clues[] cluesInInventory = new Clues[6];
+	private final Map<Integer, ClueInstance> cluesInInventory = new HashMap<>();
+	private final Map<Integer, ClueInstance> previousCluesInInventory = new HashMap<>();
 
 	// To be initialized to avoid passing around
 	@Setter
@@ -80,15 +77,12 @@ public class ClueInventoryManager
 
 	public void updateInventory(ItemContainer inventoryContainer)
 	{
-		// Copy current tracked clues to previous
-		previousTrackedCluesInInventory.clear();
-		previousTrackedCluesInInventory.putAll(trackedCluesInInventory);
+		// Copy current clues to previous
+		previousCluesInInventory.clear();
+		previousCluesInInventory.putAll(cluesInInventory);
 
-		// Clear current tracked clues
-		trackedCluesInInventory.clear();
-
-		// Clear current clues in inventory
-		cluesInInventory = new Clues[6];
+		// Clear current clues
+		cluesInInventory.clear();
 
 		Item[] inventoryItems = inventoryContainer.getItems();
 
@@ -96,27 +90,18 @@ public class ClueInventoryManager
 		{
 			if (item == null) continue;
 
-			int itemId = item.getId();
-
-			if (Clues.isTrackedClueOrTornClue(itemId, clueDetailsPlugin.isDeveloperMode()))
-			{
-				checkItemAsBeginnerOrMasterClue(itemId);
-			}
-			else
-			{
-				checkItemAsEasyToMediumClue(itemId);
-			}
+			checkItemAsClueInstance(item.getId());
 		}
 
 		clueGroundManager.getDespawnedClueQueueForInventoryCheck().clear();
 
 		// Compare previous and current to find removed clues
-		for (Integer itemId : previousTrackedCluesInInventory.keySet())
+		for (Integer itemId : previousCluesInInventory.keySet())
 		{
-			if (!trackedCluesInInventory.containsKey(itemId) || trackedCluesInInventory.get(itemId) != previousTrackedCluesInInventory.get(itemId))
+			if (!cluesInInventory.containsKey(itemId) || cluesInInventory.get(itemId) != previousCluesInInventory.get(itemId))
 			{
 				// Clue was removed from inventory (possibly dropped)
-				ClueInstance removedClue = previousTrackedCluesInInventory.get(itemId);
+				ClueInstance removedClue = previousCluesInInventory.get(itemId);
 				if (removedClue != null)
 				{
 					clueBankManager.addToRemovedClues(removedClue);
@@ -125,16 +110,7 @@ public class ClueInventoryManager
 		}
 	}
 
-	private void checkItemAsEasyToMediumClue(int id)
-	{
-		Clues clue = Clues.forItemId(id);
-		if (clue != null)
-		{
-			cluesInInventory[clue.getClueTier().getValue()] = clue;
-		}
-	}
-
-	private void checkItemAsBeginnerOrMasterClue(int itemId)
+	private void checkItemAsClueInstance(int itemId)
 	{
 		ClueInstance clueInstance;
 
@@ -144,21 +120,21 @@ public class ClueInventoryManager
 			.findFirst();
 		if (clueFromFloorInInv.isPresent())
 		{
-			trackedCluesInInventory.put(itemId, new ClueInstance(clueFromFloorInInv.get().getClueIds(), itemId));
+			cluesInInventory.put(itemId, new ClueInstance(clueFromFloorInInv.get().getClueIds(), itemId));
 			return;
 		}
 
 		// If clue is already in previous, keep the same ClueInstance
 		// This check is after the floor check as you could drop and pick up a clue in the same tick
-		clueInstance = previousTrackedCluesInInventory.get(itemId);
+		clueInstance = previousCluesInInventory.get(itemId);
 		if (clueInstance != null && Clues.isClue(clueInstance.getItemId(), clueDetailsPlugin.isDeveloperMode()))
 		{
-			trackedCluesInInventory.put(itemId, clueInstance);
+			cluesInInventory.put(itemId, clueInstance);
 		}
 		else
 		{
 			clueInstance = new ClueInstance(new ArrayList<>(), itemId);
-			trackedCluesInInventory.put(itemId, clueInstance);
+			cluesInInventory.put(itemId, clueInstance);
 		}
 	}
 
@@ -172,7 +148,7 @@ public class ClueInventoryManager
 			for (Integer devModeId : Clues.DEV_MODE_IDS)
 			{
 				int randomTestId = (int) (Math.random() * 20);
-				trackedCluesInInventory.put(devModeId, new ClueInstance(List.of(randomTestId), devModeId));
+				cluesInInventory.put(devModeId, new ClueInstance(List.of(randomTestId), devModeId));
 			}
 		}
 
@@ -191,10 +167,10 @@ public class ClueInventoryManager
 
 		if (clueIds.get(0) == null) return;
 
-		Set<Integer> itemIDs = trackedCluesInInventory.keySet();
+		Set<Integer> itemIDs = cluesInInventory.keySet();
 		for (Integer itemID : itemIDs)
 		{
-			ClueInstance clueInstance = trackedCluesInInventory.get(itemID);
+			ClueInstance clueInstance = cluesInInventory.get(itemID);
 			// Check that at least one part of the clue text matches the clue tier we're looking at
 			if (clueInstance == null) continue;
 			Clues clueInfo = Clues.forClueIdFiltered(clueIds.get(0));
@@ -214,24 +190,19 @@ public class ClueInventoryManager
 		clueIds.add(Clues.forInterfaceIdGetId(interfaceId));
 
 		// Assume can only be beginner for now
-		ClueInstance beginnerClueInInv = trackedCluesInInventory.get(ItemID.CLUE_SCROLL_BEGINNER);
+		ClueInstance beginnerClueInInv = cluesInInventory.get(ItemID.CLUE_SCROLL_BEGINNER);
 		if (beginnerClueInInv == null) return;
 		beginnerClueInInv.setClueIds(clueIds);
 	}
 
-	public Set<Integer> getTrackedCluesInInventory()
+	public Set<Integer> getCluesInInventory()
 	{
-		return trackedCluesInInventory.keySet();
+		return cluesInInventory.keySet();
 	}
 
-	public ClueInstance getTrackedClueByClueItemId(Integer clueItemID)
+	public ClueInstance getClueByClueItemId(Integer clueItemID)
 	{
-		return trackedCluesInInventory.get(clueItemID);
-	}
-
-	public boolean hasTrackedClues()
-	{
-		return !trackedCluesInInventory.isEmpty();
+		return cluesInInventory.get(clueItemID);
 	}
 
 	public void onMenuEntryAdded(MenuEntryAdded event, CluePreferenceManager cluePreferenceManager, ClueDetailsParentPanel panel)
@@ -288,15 +259,14 @@ public class ClueInventoryManager
 		// Add item highlight menu
 		if (!hasClueName(menuEntry.getTarget()))
 		{
-			if (Arrays.stream(cluesInInventory).allMatch(Objects::isNull) && trackedCluesInInventory.isEmpty()) return;
+			if (cluesInInventory.isEmpty()) return;
 
 			MenuEntry clueDetailsEntry = client.getMenu().createMenuEntry(-1)
 				.setOption("Clue details")
 				.setTarget(menuEntry.getTarget())
 				.setType(MenuAction.RUNELITE);
 			Menu submenu = clueDetailsEntry.createSubMenu();
-			Arrays.stream(cluesInInventory).forEach((clue) -> addHighlightItemMenu(cluePreferenceManager, submenu, clue, itemId, event));
-			trackedCluesInInventory.forEach((id, instance) -> instance.getClueIds().forEach((clueId) -> addHighlightItemMenu(cluePreferenceManager, submenu, Clues.forClueIdFiltered(clueId), itemId, event)));
+			cluesInInventory.forEach((id, instance) -> instance.getClueIds().forEach((clueId) -> addHighlightItemMenu(cluePreferenceManager, submenu, Clues.forClueIdFiltered(clueId), itemId, event)));
 			return;
 		}
 
@@ -324,7 +294,7 @@ public class ClueInventoryManager
 
 		if (Clues.isBeginnerOrMasterClue(itemId, clueDetailsPlugin.isDeveloperMode()))
 		{
-			ClueInstance clueSelected = trackedCluesInInventory.get(itemId);
+			ClueInstance clueSelected = cluesInInventory.get(itemId);
 			if (clueSelected == null || clueSelected.getClueIds().isEmpty()) return;
 
 			clueIds.addAll(clueSelected.getClueIds());
@@ -466,14 +436,14 @@ public class ClueInventoryManager
 		if (isNewBeginnerClue(chatDialogClueItemWidget)
 			|| (isUriBeginnerClue(headModelWidget) && isUriStandardDialogue(npcChatWidget)))
 		{
-			ClueInstance clue = trackedCluesInInventory.get(ItemID.CLUE_SCROLL_BEGINNER);
+			ClueInstance clue = cluesInInventory.get(ItemID.CLUE_SCROLL_BEGINNER);
 			if (clue == null) return;
 			clue.setClueIds(List.of());
 		}
 		else if (isNewMasterClue(chatDialogClueItemWidget)
 			|| (isUriMasterClue(headModelWidget) && isUriStandardDialogue(npcChatWidget)))
 		{
-			ClueInstance clue =  trackedCluesInInventory.get(ItemID.CLUE_SCROLL_MASTER);
+			ClueInstance clue =  cluesInInventory.get(ItemID.CLUE_SCROLL_MASTER);
 			if (clue == null) return;
 			clue.setClueIds(List.of());
 		}


### PR DESCRIPTION
Functions relating to showInventoryCluesOverlay were not functioning for easy-elite clues. This simplifies the logic to treat all inventory clues as "tracked" clues.

Fixes the issue but this might be overkill for the sake of simplicity 