### PR TITLE
fix: ClueGroundTimer cleanup; Add renotification

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -602,13 +602,26 @@ public interface ClueDetailsConfig extends Config
 	@ConfigItem(
 		keyName = "groundClueTimersNotificationTime",
 		name = "Timer notifications",
-		description = "Time remaining (seconds) until despawn to send notification. Set to 0 to disable the notification.",
+		description = "Seconds remaining until despawn per tile to send notification. Set to 0 to disable the notification.",
 		section = groundCluesSection,
 		position = 7
 	)
 	default int groundClueTimersNotificationTime()
 	{
 		return 60;
+	}
+
+	@ConfigItem(
+		keyName = "groundClueTimersRenotificationTime",
+		name = "Timer renotifications",
+		description = "Seconds after initial notificiaton to periodically renotify. Set to 0 to disable the notification." +
+			"<br> This also acts as a cooldown between notifications for clues in the same tile",
+		section = groundCluesSection,
+		position = 8
+	)
+	default int groundClueTimersRenotificationTime()
+	{
+		return 0;
 	}
 
 	@ConfigSection(name = "Tier Toggles", description = "Options to enable particular clue tiers", position = 7)

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.TimerTask;
 import java.util.TreeMap;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -74,7 +75,6 @@ import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.ImageUtil;
-import net.runelite.client.util.RSTimeUnit;
 
 @Slf4j
 @PluginDescriptor(
@@ -162,6 +162,7 @@ public class ClueDetailsPlugin extends Plugin
 	private ChatboxItemSearch itemSearch;
 
 	@Inject
+	@Getter
 	private Notifier notifier;
 
 	@Inject
@@ -346,10 +347,17 @@ public class ClueDetailsPlugin extends Plugin
 			{
 				for (ClueGroundTimer timer : clueGroundTimers)
 				{
-					if (!timer.isNotified() && timer.shouldNotify())
+					if (!timer.isNotified() && timer.shouldNotify() && !timer.isRenotifying())
 					{
 						notifier.notify("Your clue scroll is about to disappear!");
-						timer.setNotified(true);
+						if (config.groundClueTimersRenotificationTime() != 0)
+						{
+							timer.startRenotification();
+						}
+						else
+						{
+							timer.setNotified(true);
+						}
 					}
 					else if (timer.isNotified() && !timer.shouldNotify())
 					{
@@ -428,22 +436,15 @@ public class ClueDetailsPlugin extends Plugin
 			}
 		}
 
-		// renderGroundClueTimers if showGroundClueTimers toggled or tier toggled
-		if ("showGroundClueTimers".equals(event.getKey()) || event.getKey().contains("Details"))
+		// Reset clueGroundTimers when showGroundClueTimers toggled off
+		if ("showGroundClueTimers".equals(event.getKey()) && "false".equals(event.getNewValue()))
 		{
-			if ("showGroundClueTimers".equals(event.getKey()) && "false".equals(event.getNewValue()))
+			// Reset timers
+			for (ClueGroundTimer timer : clueGroundTimers)
 			{
-				// Reset timers
-				for (ClueGroundTimer timer : clueGroundTimers)
-				{
-					infoBoxManager.removeInfoBox(timer);
-				}
-				clueGroundTimers.clear();
+				infoBoxManager.removeInfoBox(timer);
 			}
-			else
-			{
-				renderGroundClueTimers();
-			}
+			clueGroundTimers.clear();
 		}
 
 		panel.refresh();
@@ -494,10 +495,7 @@ public class ClueDetailsPlugin extends Plugin
 					}
 				}
 
-				Duration duration = Duration.of(
-					oldestEnabledClueInstance.getTicksToDespawnConsideringTileItem(client.getTickCount()),
-					RSTimeUnit.GAME_TICKS
-				);
+				int despawnTick = oldestEnabledClueInstance.getDespawnTick(client.getTickCount());
 
 				boolean createNewTimer = true;
 
@@ -506,8 +504,8 @@ public class ClueDetailsPlugin extends Plugin
 				{
 					if (worldPoint.equals(timer.getWorldPoint()))
 					{
-						timer.updateDuration(duration);
 						timer.setClueInstancesWithQuantity(clueInstancesWithQuantityAtWp);
+						timer.setDespawnTick(despawnTick);
 						createNewTimer = false;
 						break;
 					}
@@ -516,10 +514,11 @@ public class ClueDetailsPlugin extends Plugin
 				if (createNewTimer)
 				{
 					ClueGroundTimer timer = new ClueGroundTimer(
+						client,
 						this,
 						config,
 						configManager,
-						duration,
+						despawnTick,
 						worldPoint,
 						clueInstancesWithQuantityAtWp,
 						itemManager.getImage(ItemID.CLUE_SCROLL_23815)

--- a/src/main/java/com/cluedetails/ClueGroundOverlay.java
+++ b/src/main/java/com/cluedetails/ClueGroundOverlay.java
@@ -141,6 +141,36 @@ public class ClueGroundOverlay extends Overlay
 		return null;
 	}
 
+	private int getSecondsLeft(ClueInstance item)
+	{
+		int ticksLeft = item.getDespawnTick(client.getTickCount()) - client.getTickCount();
+		int millisLeft = ticksLeft * 600;
+		return (int) (millisLeft / 1000L);
+	}
+
+	public String getDespawnText(ClueInstance item)
+	{
+		int seconds = getSecondsLeft(item);
+		int minutes = seconds / 60;
+		int secs = seconds % 60;
+		if (minutes < 10)
+		{
+			if (minutes < 1)
+			{
+				return String.format("%ds", secs);
+			}
+			return String.format("%d:%02d", minutes, secs);
+		}
+		return String.format("%dm", minutes);
+	}
+
+	public Color getTextColor(ClueInstance item)
+	{
+		return getSecondsLeft(item) < config.groundClueTimersNotificationTime()
+			? Color.RED
+			: Color.WHITE;
+	}
+
 	private void renderClueInstanceGroundOverlay(Graphics2D graphics, ClueInstance item, int quantity, LocalPoint groundPoint, FontMetrics fm)
 	{
 		final String itemString = item.getGroundText(plugin, config, configManager, quantity);
@@ -163,10 +193,9 @@ public class ClueGroundOverlay extends Overlay
 
 		if (config.showGroundCluesDespawn())
 		{
-			Integer despawnTime = item.getDespawnTick(client.getTickCount()) - client.getTickCount();
-			Color timerColor = Color.WHITE;
+			Color timerColor = getTextColor(item);
 
-			final String timerText = String.format(" - %d", despawnTime);
+			final String timerText = String.format(" - %s", getDespawnText(item));
 
 			// The timer text is drawn separately to have its own color, and is intentionally not included
 			// in the getCanvasTextLocation() call because the timer text can change per frame and we do not


### PR DESCRIPTION
- Changed ClueGroundTimer to be an InfoBox instead of Timer
- Normalized Ground Clues Overlay and Ground Clue Timers time format to seconds
  - Previously was mix of seconds & ticks
- Added renotify configuration to provide recurring notification for WorldPoints which should be notified
  - This should be help by providing reminders for large stacks of clues without requiring spamming notifications as each despawn timer passes the configured threshold