### PR TITLE
fix: Add check for if clue being added to inventory store is a clue

### DIFF
--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -114,6 +114,8 @@ public class ClueInventoryManager
 	{
 		ClueInstance clueInstance;
 
+		if (!Clues.isClue(itemId, clueDetailsPlugin.isDeveloperMode())) return;
+
 		// If we have a clue we've picked up this tick, we've probably dropped and picked up a clue same tick
 		Optional<ClueInstance> clueFromFloorInInv = clueGroundManager.getDespawnedClueQueueForInventoryCheck().stream()
 			.filter(clueFromFloor ->  clueFromFloor.getItemId() == itemId)


### PR DESCRIPTION
Stuff like blood runes was being added incorrectly for the inventory overlay.