### PR TITLE
fix: invalidate clue items cache on new beginner or master clue

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -108,6 +108,7 @@ public class ClueDetailsPlugin extends Plugin
 	@Inject
 	private ClueDetailsInventoryOverlay inventoryOverlay;
 
+	@Getter
 	@Inject
 	private ClueDetailsItemsOverlay itemsOverlay;
 

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -441,6 +441,7 @@ public class ClueInventoryManager
 			ClueInstance clue = cluesInInventory.get(ItemID.CLUE_SCROLL_BEGINNER);
 			if (clue == null) return;
 			clue.setClueIds(List.of());
+			clueDetailsPlugin.getItemsOverlay().invalidateCache();
 		}
 		else if (isNewMasterClue(chatDialogClueItemWidget)
 			|| (isUriMasterClue(headModelWidget) && isUriStandardDialogue(npcChatWidget)))
@@ -448,6 +449,7 @@ public class ClueInventoryManager
 			ClueInstance clue =  cluesInInventory.get(ItemID.CLUE_SCROLL_MASTER);
 			if (clue == null) return;
 			clue.setClueIds(List.of());
+			clueDetailsPlugin.getItemsOverlay().invalidateCache();
 		}
 	}
 


### PR DESCRIPTION
Highlighted items for beginner and master steps would persist until onItemContainerChanged. This resets them after each step.