### PR TITLE
Support Marking Beginner and Master clues

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -442,11 +442,6 @@ public class ClueDetailsPlugin extends Plugin
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
-		if (event.getGroup().equals("clue-details-highlights"))
-		{
-			infoOverlay.refreshHighlights();
-		}
-
 		if (event.getKey().equals("beginnerDetails")
 			|| event.getKey().equals("easyDetails")
 			|| event.getKey().equals("mediumDetails")

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -41,6 +41,8 @@ import net.runelite.api.Menu;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.NpcID;
+import net.runelite.api.Tile;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.InterfaceID;
@@ -253,16 +255,13 @@ public class ClueInventoryManager
 		final Widget w = entry.getWidget();
 		boolean isInventoryMenu = w != null && WidgetUtil.componentToInterface(w.getId()) == InterfaceID.INVENTORY;
 
-		int itemId = isInventoryMenu ? event.getItemId() : event.getIdentifier();
-		// Runs on both inventory and ground clues
-		if (hasClueName(event.getMenuEntry().getTarget()))
-		{
-			handleMarkClue(cluePreferenceManager, panel, event.getTarget(), itemId);
-		}
-
 		if (isInventoryMenu)
 		{
 			handleInventory(cluePreferenceManager, event, panel);
+		}
+		else
+		{
+			handleGround(cluePreferenceManager, panel, event);
 		}
 	}
 
@@ -287,17 +286,6 @@ public class ClueInventoryManager
 
 		// Is a clue item, add clue item menu entries
 		handleClueDetailsMenuEntry(panel, menuEntry, itemId);
-	}
-
-	private void handleMarkClue(CluePreferenceManager cluePreferenceManager, ClueDetailsParentPanel panel, String name, int itemId)
-	{
-		boolean isMarked = cluePreferenceManager.getHighlightPreference(itemId);
-
-		// Mark Option
-		if (!Clues.isBeginnerOrMasterClue(itemId, clueDetailsPlugin.isDeveloperMode()))
-		{
-			toggleMarkClue(cluePreferenceManager, panel, itemId, isMarked, name);
-		}
 	}
 
 	private void handleClueDetailsMenuEntry(ClueDetailsParentPanel panel, MenuEntry entry, int itemId)
@@ -390,18 +378,49 @@ public class ClueInventoryManager
 				updateClueItems(clue, itemId, cluePreferenceManager));
 	}
 
-	private void toggleMarkClue(CluePreferenceManager cluePreferenceManager, ClueDetailsParentPanel panel, int clueId, boolean isMarked, String target)
+	private void handleGround(CluePreferenceManager cluePreferenceManager, ClueDetailsParentPanel panel, MenuEntryAdded event)
 	{
-		// We don't want to have marking on masters I think
+		if(!hasClueName(event.getMenuEntry().getTarget())) return;
+
+		int itemId = event.getIdentifier();
+		Clues clue = Clues.forItemId(itemId);
+		int clueId;
+
+		if (clue != null)
+		{
+			clueId = itemId;
+		}
+		else
+		{
+			Tile tile = client.getSelectedSceneTile();
+			if (tile == null) return;
+
+			WorldPoint worldPoint = tile.getWorldLocation();
+			SortedSet<ClueInstance> clueInstances = clueGroundManager.getAllGroundCluesOnWp(worldPoint);
+			if (clueInstances.isEmpty())
+			{
+				return;
+			}
+			else
+			{
+				// TODO: Only supports 1 beginner or master per tile
+				List<Integer> clueIds = clueInstances.first().getClueIds();
+				// Don't provide mark option for three-step cryptic clues
+				if (clueIds.size() > 1) return;
+				clueId = clueIds.get(0);
+			}
+		}
+
+		boolean isMarked = cluePreferenceManager.getHighlightPreference(clueId);
+
 		client.getMenu().createMenuEntry(-1)
 			.setOption(isMarked ? "Unmark" : "Mark")
-			.setTarget(target)
-			.setIdentifier(clueId)
+			.setTarget(event.getTarget())
+			.setIdentifier(itemId)
 			.setType(MenuAction.RUNELITE)
 			.onClick(e ->
 			{
-				boolean currentValue = cluePreferenceManager.getHighlightPreference(e.getIdentifier());
-				cluePreferenceManager.saveHighlightPreference(e.getIdentifier(), !currentValue);
+				cluePreferenceManager.saveHighlightPreference(clueId, !isMarked);
 				panel.refresh();
 			});
 	}

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1220,6 +1220,11 @@ public class Clues
 		return null;
 	}
 
+	public boolean getMarked(ConfigManager configManager)
+	{
+		return "true".equals(configManager.getConfiguration("clue-details-highlights", String.valueOf(getClueID())));
+	}
+
 	public static boolean isClue(int itemId, boolean isDeveloperMode)
 	{
 		return itemIdClueCache.containsKey(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));


### PR DESCRIPTION
Mark right click option is only present on ground items

All beginner and master clues can be marked via sidebar and are correctly renderered on the floor

TODO:
- Right click only supports 1 beginner/master per tile
- How should notifications work for beginner/master, or tracked clues in general?

Closes #73