### PR TITLE
fix: Ground Items collapse conflicts

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -204,7 +204,11 @@ public class ClueDetailsOverlay extends OverlayPanel
 			return;
 		}
 
-		changeGroundItemMenu(getEntriesByTile(menuEntries));
+		// Don't run when client.isMenuOpen due to conflict with Ground Items "Collapse ground item menu"
+		if (!client.isMenuOpen())
+		{
+			changeGroundItemMenu(getEntriesByTile(menuEntries));
+		}
 	}
 
 	@Subscribe

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -192,7 +192,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 		addTooltip(getEntriesByTile(currentMenuEntries));
 	}
 
-	// Using onClientTick for compatability with Ground Items "Collapse ground item menu"
+	// Using onClientTick for compatibility with Ground Items "Collapse ground item menu"
 	@Subscribe
 	public void onClientTick(ClientTick event)
 	{
@@ -223,6 +223,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 
 	private void changeGroundItemMenu(List<MenuEntryAndPos> entriesByTile)
 	{
+		int threeStepCount = 0;
 		// Change ground item menu text
 		for (MenuEntryAndPos entryAndPos : entriesByTile)
 		{
@@ -256,7 +257,9 @@ public class ClueDetailsOverlay extends OverlayPanel
 			// Handle master three-step cryptic
 			if (newText.split("<br>").length > 1)
 			{
-				newText = "Three-step (master)";
+				// Add unique col tag for compatibility with Ground Items "Collapse ground item menu"
+				newText = "Three-step (master)<col=" + String.format("%0" + 8 + "d", threeStepCount) + ">";
+				threeStepCount++;
 			}
 			// Replace the matched text with the new text
 			String newTarget = matcher.replaceAll(newText);

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -459,7 +459,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 			ClueInstance clueInstance = clueInventoryManager.getClueByClueItemId(scrollID);
 			if (clueInstance != null && !clueInstance.getClueIds().isEmpty())
 			{
-				return clueInstance.getCombinedClueText(clueDetailsPlugin, configManager, showColor, isFloorText);
+				return clueInstance.getCombinedClueText(configManager, showColor, isFloorText);
 			}
 		}
 
@@ -515,7 +515,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 		ClueInstance clueInstance = getTrackedClueInstance(entry);
 		if (clueInstance == null) return null;
 
-		return clueInstance.getCombinedClueText(clueDetailsPlugin, configManager, showColor, isFloorText);
+		return clueInstance.getCombinedClueText(configManager, showColor, isFloorText);
 	}
 
 	private Color getTrackedClueColor(MenuEntryAndPos entry)

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -215,7 +215,7 @@ public class ClueInstance
 		return timeToDespawnFromDataInTicks == null ? -1 : timeToDespawnFromDataInTicks;
 	}
 
-	public String getCombinedClueText(ClueDetailsPlugin plugin, ConfigManager configManager, boolean showColor, boolean isFloorText)
+	public String getCombinedClueText(ConfigManager configManager, boolean showColor, boolean isFloorText)
 	{
 		StringBuilder returnText = new StringBuilder();
 		boolean isFirst = true;
@@ -246,7 +246,7 @@ public class ClueInstance
 
 			returnText.append(cluePart.getDetail(configManager));
 		}
-		if (returnText.length() == 0) return getItemName(plugin);
+		if (returnText.length() == 0) return null;
 		return returnText.toString();
 	}
 


### PR DESCRIPTION
1. Ground Items "Collapse ground item menu" count was getting clobbered by menuEntry target update
  - Before
    - ![image](https://github.com/user-attachments/assets/5abaad0a-57c1-42cb-870b-53c130020175)
  - After
    - ![image](https://github.com/user-attachments/assets/7da5653b-3954-41ed-8069-b3f787529c3f)

2. "Three-step (master)" menu entries were being collapsed by Ground Items "Collapse ground item menu", meaning unique submenus could not be provided per unique three step
  - Added trailing <col> tag per entry to ensure collapse doesn't apply

3. After the above changes, unidentified beginner & master clue scrolls were being incorrectly renamed due to "Collapse ground item menu"
  - Only run changeGroundItemMenu when !client.isMenuOpen() to avoid conflict
