### PR TITLE
2.3.3 Cleanup

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -511,7 +511,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 		int sceneY = menuEntry.getParam1();
 		int wv = menuEntry.getWorldViewId();
 		LocalPoint itemLp = new LocalPoint(sceneX * SCENE_TO_LOCAL, sceneY * SCENE_TO_LOCAL, wv);
-		WorldPoint itemWp = WorldPoint.fromLocalInstance(client, itemLp);
+		WorldPoint itemWp = WorldPoint.fromLocal(client, itemLp);
 		List<ClueInstance> trackedClues = new ArrayList<>(clueGroundManager.getAllGroundCluesOnWp(itemWp));
 		if (trackedClues.size() <= entry.getPosOnTile()) return null;
 		return trackedClues.get(entry.getPosOnTile());

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -252,10 +252,7 @@ public class ClueDetailsPlugin extends Plugin
 		clueGroundManager.saveStateToConfig();
 		clueBankManager.saveStateToConfig();
 
-		for (ClueGroundTimer timer : clueGroundTimers)
-		{
-			infoBoxManager.removeInfoBox(timer);
-		}
+		resetClueGroundTimers();
 	}
 
 	@Subscribe
@@ -441,12 +438,7 @@ public class ClueDetailsPlugin extends Plugin
 		// Reset clueGroundTimers when showGroundClueTimers toggled off
 		if ("showGroundClueTimers".equals(event.getKey()) && "false".equals(event.getNewValue()))
 		{
-			// Reset timers
-			for (ClueGroundTimer timer : clueGroundTimers)
-			{
-				infoBoxManager.removeInfoBox(timer);
-			}
-			clueGroundTimers.clear();
+			resetClueGroundTimers();
 		}
 
 		panel.refresh();
@@ -530,5 +522,14 @@ public class ClueDetailsPlugin extends Plugin
 				}
 			}
 		}
+	}
+
+	private void resetClueGroundTimers()
+	{
+		for (ClueGroundTimer timer : clueGroundTimers)
+		{
+			infoBoxManager.removeInfoBox(timer);
+		}
+		clueGroundTimers.clear();
 	}
 }

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -436,7 +436,7 @@ public class ClueGroundManager
 
 		for (ClueInstance item : items)
 		{
-			List<Integer> clueIds = item.getClueIds();
+			List<Integer> clueIds = item.getUniqueIds();
 
 			if (!lowestValueItems.containsKey(clueIds)
 				|| item.getDespawnTick(currentTick) < lowestValueItems.get(clueIds).getDespawnTick(currentTick))
@@ -451,7 +451,7 @@ public class ClueGroundManager
 		}
 
 		return lowestValueItems.values().stream()
-			.collect(Collectors.toMap(item -> item, item -> uniqueCount.get(item.getClueIds())));
+			.collect(Collectors.toMap(item -> item, item -> uniqueCount.get(item.getUniqueIds())));
 	}
 
 	// Remove duplicate tier clues, maintaining a count of the original amount of each

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -104,6 +104,16 @@ public class ClueInstance
 		return clueIds;
 	}
 
+	public List<Integer> getUniqueIds()
+	{
+		if (clueIds.isEmpty())
+		{
+			return Collections.singletonList(itemId);
+		}
+
+		return clueIds;
+	}
+
 	public ClueTier getTier()
 	{
 		Clues clue;
@@ -119,6 +129,8 @@ public class ClueInstance
 
 		if (clue == null)
 		{
+			if (itemId == ItemID.CLUE_SCROLL_BEGINNER) return ClueTier.BEGINNER;
+			if (itemId == ItemID.CLUE_SCROLL_MASTER) return ClueTier.MASTER;
 			return null;
 		}
 		return clue.getClueTier();
@@ -257,7 +269,11 @@ public class ClueInstance
 
 	public boolean isEnabled(ClueDetailsConfig config)
 	{
-		if (itemId == ItemID.CLUE_SCROLL_BEGINNER || Clues.DEV_MODE_IDS.contains(itemId))
+		if (Clues.DEV_MODE_IDS.contains(itemId))
+		{
+			return config.beginnerDetails();
+		}
+		else if (getTier() == ClueTier.BEGINNER)
 		{
 			return config.beginnerDetails();
 		}
@@ -277,7 +293,7 @@ public class ClueInstance
 		{
 			return config.eliteDetails();
 		}
-		else if (itemId == ItemID.CLUE_SCROLL_MASTER)
+		else if (getTier() == ClueTier.MASTER)
 		{
 			return config.masterDetails();
 		}

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -114,7 +114,8 @@ public class ClueInventoryManager
 	{
 		ClueInstance clueInstance;
 
-		if (!Clues.isClue(itemId, clueDetailsPlugin.isDeveloperMode())) return;
+		if (!Clues.isClue(itemId, clueDetailsPlugin.isDeveloperMode())
+			&& !Clues.isTrackedClueOrTornClue(itemId, clueDetailsPlugin.isDeveloperMode())) return;
 
 		// If we have a clue we've picked up this tick, we've probably dropped and picked up a clue same tick
 		Optional<ClueInstance> clueFromFloorInInv = clueGroundManager.getDespawnedClueQueueForInventoryCheck().stream()


### PR DESCRIPTION
- fix: Track torn clues in inventory
- fix: Properly reset Clue Ground Timers
- fix: Collapse options handle unidentified beginner/master
- fix: Support changed clue text in instances
- TODO: https://github.com/Zoinkwiz/clue-details/compare/df5617db5732a6ac73994980a13ca96d5a89f006...Zoinkwiz:40598bb04c0963eac6a8cc39106e59ab148b1116?w=1#diff-c7c5dc63368698b83764009ffc6713a33d3238d0946b0aa2b87063af89de0551R260 missing a developer mode check
- TODO: Noticed this one is not always true. I noticed it consistently when going up/down planes. Results in Clues being "forgotten"
  - https://github.com/Zoinkwiz/clue-details/blob/master/src/main/java/com/cluedetails/ClueGroundManager.java#L167
  - https://i.imgur.com/bnf7MjU.gif