### PR TITLE
Add widget highlighting for clues

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ The "Inventory tag clue items" toggle applies inventory tags to configured items
 
 ![image](https://github.com/user-attachments/assets/3dc33f5b-f300-4614-b6bf-db7359f23ae5)
 
+The "Highlight clue widgets" toggle highlights configured widgets on the user interface for each clue in your inventory using configured clue colors
+
+![image](https://github.com/user-attachments/assets/9a3a66bb-0476-4fdd-ae0e-76c63fd28078)
+
 The "Show ground clues" toggle shows text overlay for ground clues, similar to the Ground Items plugin.
 
 ![ground_clues](https://github.com/user-attachments/assets/bb067da3-faaf-4d5f-a521-d1c3b030ab9b)

--- a/src/main/java/com/cluedetails/ClueBankManager.java
+++ b/src/main/java/com/cluedetails/ClueBankManager.java
@@ -104,6 +104,7 @@ public class ClueBankManager
 		clue.setClueIds(clueFromBank.getClueIds());
 
 		cluesInBank.remove(trackedClueId);
+		clueInventoryManager.updateLastInventoryRefreshTime();
 	}
 
 	public void addToRemovedClues(ClueInstance clueInstance)

--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -409,6 +409,20 @@ public interface ClueDetailsConfig extends Config
 		return true;
 	}
 
+	@ConfigItem(
+		keyName = "highlightInventoryClueWidgets",
+		name = "Inventory tag clue widgets",
+		description = "Toggle whether to apply inventory tags to configured widgets for each clue in your inventory" +
+			"<br>Display mode is managed by Inventory Tags configuration" +
+			"<br>Alpha will always be used from 'Clue widgets color'",
+		section = overlaysSection,
+		position = 7
+	)
+	default boolean highlightInventoryClueWidgets()
+	{
+		return true;
+	}
+
 	@ConfigSection(name = "Overlay Colors", description = "Options that effect overlay colors", position = 5)
 	String overlayColorsSection = "Overlay Colors";
 

--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -411,12 +411,11 @@ public interface ClueDetailsConfig extends Config
 
 	@ConfigItem(
 		keyName = "highlightInventoryClueWidgets",
-		name = "Inventory tag clue widgets",
-		description = "Toggle whether to apply inventory tags to configured widgets for each clue in your inventory" +
-			"<br>Display mode is managed by Inventory Tags configuration" +
-			"<br>Alpha will always be used from 'Clue widgets color'",
+		name = "Highlight clue widgets",
+		description = "Toggle whether to highlight widgets configured for each clue in your inventory." +
+			"<br>Opacity will always be used from 'Clue widgets color'",
 		section = overlaysSection,
-		position = 7
+		position = 8
 	)
 	default boolean highlightInventoryClueWidgets()
 	{

--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -40,6 +40,7 @@ import net.runelite.client.config.*;
 public interface ClueDetailsConfig extends Config
 {
 	String CLUE_ITEMS_CONFIG = "clue-details-items";
+	String CLUE_WIDGETS_CONFIG = "clue-details-widgets";
 
 	enum ClueOrdering implements Comparator<Clues>
 	{
@@ -485,12 +486,38 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "colorInventoryClueWidgets",
+		name = "Color clue widgets",
+		description = "Toggle whether apply clue details color to clue widgets",
+		section = overlayColorsSection,
+		position = 6
+	)
+	default boolean colorInventoryClueWidgets()
+	{
+		return true;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "widgetHighlightColor",
+		name = "Clue widgets color",
+		description = "Clue widgets color used when \"Color clue widgets\" is toggled on",
+		section = overlayColorsSection,
+		position = 7
+	)
+	default Color widgetHighlightColor()
+	{
+		Color baseColor = Color.YELLOW.darker();
+		return new Color(baseColor.getRed(), baseColor.getGreen(), baseColor.getBlue(), 128);
+	}
+
+	@ConfigItem(
 		keyName = "colorGroundItems",
 		name = "Overwrite Ground Items colors",
 		description = "When updating clue details colors, apply the color to the Ground Items plugin" +
 			"<br>Does apply to Beginner and Master clues. Set color to #FFFFFF to reset.",
 		section = overlayColorsSection,
-		position = 7
+		position = 9
 	)
 	default boolean colorGroundItems()
 	{
@@ -503,7 +530,7 @@ public interface ClueDetailsConfig extends Config
 		description = "When updating clue details colors, apply the color to the Inventory Tags plugin" +
 			"<br>Does apply to Beginner and Master clues. Set color to #FFFFFF to reset.",
 		section = overlayColorsSection,
-		position = 6
+		position = 8
 	)
 	default boolean colorInventoryTags()
 	{

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -31,8 +31,6 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
-import java.awt.Rectangle;
-import java.awt.geom.Area;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -57,7 +55,6 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemDespawned;
 import net.runelite.api.events.ItemSpawned;
 import net.runelite.api.events.MenuOpened;
-import net.runelite.api.widgets.Widget;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -135,55 +132,6 @@ public class ClueDetailsOverlay extends OverlayPanel
 		}
 
 		tileHighlights.keySet().forEach(tile -> checkAllTilesForHighlighting(tile, tileHighlights.get(tile)));
-
-		if (config.colorInventoryClueWidgets())
-		{
-			Set<Integer> clueWidgetIds = clueInventoryManager.getClueWidgetIds();
-			if (!clueWidgetIds.isEmpty())
-			{
-				Color originalColor = graphics.getColor();
-				graphics.setColor(config.widgetHighlightColor());
-				for (int widgetId : clueWidgetIds)
-				{
-					Widget widget = client.getWidget(widgetId);
-					if (widget == null || widget.isHidden())
-					{
-						continue;
-					}
-
-					// Highlight as much of the widget as is visible of it inside its parent
-					Widget parent = widget.getParent();
-					if (parent != null)
-					{
-						Point widgetLocation = widget.getCanvasLocation();
-						if (widgetLocation == null)
-						{
-							continue;
-						}
-
-						Point parentLocation = parent.getCanvasLocation();
-						if (parentLocation.getY() > widgetLocation.getY() + widget.getHeight()
-							|| parentLocation.getY() + parent.getHeight() < widgetLocation.getY())
-						{
-							continue;
-						}
-
-						int x = widgetLocation.getX(); // no horizontal scrolling affecting location
-						int y = Math.max(widgetLocation.getY(), parentLocation.getY());
-						int width = widget.getWidth(); // no horizontal scrolling affecting width
-						int height = Math.min(widget.getHeight(), parent.getHeight());
-
-						Area widgetArea = new Area(new Rectangle(x, y, width, height));
-						graphics.fill(widgetArea);
-					}
-					else
-					{
-						graphics.fill(widget.getBounds());
-					}
-				}
-				graphics.setColor(originalColor);
-			}
-		}
 
 		return super.render(graphics);
 	}

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -31,6 +31,8 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
+import java.awt.Rectangle;
+import java.awt.geom.Area;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,6 +57,7 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemDespawned;
 import net.runelite.api.events.ItemSpawned;
 import net.runelite.api.events.MenuOpened;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -132,6 +135,55 @@ public class ClueDetailsOverlay extends OverlayPanel
 		}
 
 		tileHighlights.keySet().forEach(tile -> checkAllTilesForHighlighting(tile, tileHighlights.get(tile)));
+
+		if (config.colorInventoryClueWidgets())
+		{
+			Set<Integer> clueWidgetIds = clueInventoryManager.getClueWidgetIds();
+			if (!clueWidgetIds.isEmpty())
+			{
+				Color originalColor = graphics.getColor();
+				graphics.setColor(config.widgetHighlightColor());
+				for (int widgetId : clueWidgetIds)
+				{
+					Widget widget = client.getWidget(widgetId);
+					if (widget == null || widget.isHidden())
+					{
+						continue;
+					}
+
+					// Highlight as much of the widget as is visible of it inside its parent
+					Widget parent = widget.getParent();
+					if (parent != null)
+					{
+						Point widgetLocation = widget.getCanvasLocation();
+						if (widgetLocation == null)
+						{
+							continue;
+						}
+
+						Point parentLocation = parent.getCanvasLocation();
+						if (parentLocation.getY() > widgetLocation.getY() + widget.getHeight()
+							|| parentLocation.getY() + parent.getHeight() < widgetLocation.getY())
+						{
+							continue;
+						}
+
+						int x = widgetLocation.getX(); // no horizontal scrolling affecting location
+						int y = Math.max(widgetLocation.getY(), parentLocation.getY());
+						int width = widget.getWidth(); // no horizontal scrolling affecting width
+						int height = Math.min(widget.getHeight(), parent.getHeight());
+
+						Area widgetArea = new Area(new Rectangle(x, y, width, height));
+						graphics.fill(widgetArea);
+					}
+					else
+					{
+						graphics.fill(widget.getBounds());
+					}
+				}
+				graphics.setColor(originalColor);
+			}
+		}
 
 		return super.render(graphics);
 	}

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -415,6 +415,11 @@ public class ClueDetailsPlugin extends Plugin
 			infoOverlay.refreshHighlights();
 		}
 
+		if (event.getGroup().equals(config.CLUE_WIDGETS_CONFIG))
+		{
+			widgetsOverlay.refreshWidgets();
+		}
+
 		if (event.getKey().equals("beginnerDetails")
 			|| event.getKey().equals("easyDetails")
 			|| event.getKey().equals("mediumDetails")

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -429,7 +429,7 @@ public class ClueDetailsPlugin extends Plugin
 			|| event.getKey().equals("masterDetails"))
 		{
 			Clues.rebuildFilteredCluesCache();
-			widgetsOverlay.populateInventoryCluesWidgetColors();
+			clueInventoryManager.updateLastInventoryRefreshTime();
 		}
 
 		if (event.getGroup().equals("clue-details-color")
@@ -447,7 +447,7 @@ public class ClueDetailsPlugin extends Plugin
 			|| event.getKey().equals("colorInventoryClueWidgets")
 			|| event.getGroup().equals("clue-details-color"))
 		{
-			widgetsOverlay.populateInventoryCluesWidgetColors();
+			clueInventoryManager.updateLastInventoryRefreshTime();
 		}
 
 		if (!event.getGroup().equals(ClueDetailsConfig.class.getAnnotation(ConfigGroup.class).value()))

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -148,6 +148,9 @@ public class ClueDetailsPlugin extends Plugin
 	private ClueInventoryManager clueInventoryManager;
 
 	@Getter
+	private ClueWidgetManager clueWidgetManager;
+
+	@Getter
 	private ClueGroundManager clueGroundManager;
 
 	private ClueBankManager clueBankManager;
@@ -208,11 +211,13 @@ public class ClueDetailsPlugin extends Plugin
 		Clues.setConfig(config);
 		Clues.rebuildFilteredCluesCache();
 		ClueInventoryManager.setConfig(config);
+		ClueWidgetManager.setConfig(config);
 
 		cluePreferenceManager = new CluePreferenceManager(this, configManager);
 		clueGroundManager = new ClueGroundManager(client, configManager, this);
 		clueBankManager = new ClueBankManager(client, configManager, gson);
 		clueInventoryManager = new ClueInventoryManager(client, configManager, this, clueGroundManager, clueBankManager, chatboxPanelManager);
+		clueWidgetManager = new ClueWidgetManager(client, configManager, clueInventoryManager, cluePreferenceManager);
 		clueBankManager.startUp(clueInventoryManager);
 
 		infoOverlay.startUp(this, clueGroundManager, clueInventoryManager);
@@ -405,7 +410,7 @@ public class ClueDetailsPlugin extends Plugin
 	public void onMenuOpened(MenuOpened event)
 	{
 		MenuEntry[] entries = event.getMenuEntries();
-		clueInventoryManager.addHighlightWidgetSubmenus(entries, cluePreferenceManager);
+		clueWidgetManager.addHighlightWidgetSubmenus(entries);
 	}
 
 	@Subscribe

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -28,11 +28,9 @@ import com.cluedetails.panels.ClueDetailsParentPanel;
 import com.google.gson.Gson;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.TimerTask;
 import java.util.TreeMap;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -42,6 +40,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemID;
+import net.runelite.api.MenuEntry;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.GameStateChanged;
@@ -50,6 +49,7 @@ import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.ItemDespawned;
 import net.runelite.api.events.ItemSpawned;
 import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.events.MenuOpened;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.InterfaceID;
@@ -148,6 +148,7 @@ public class ClueDetailsPlugin extends Plugin
 
 	private ClueBankManager clueBankManager;
 
+	@Getter
 	private CluePreferenceManager cluePreferenceManager;
 
 	@Getter
@@ -392,6 +393,13 @@ public class ClueDetailsPlugin extends Plugin
 	public void onMenuEntryAdded(MenuEntryAdded event)
 	{
 		clueInventoryManager.onMenuEntryAdded(event, cluePreferenceManager, panel);
+	}
+
+	@Subscribe
+	public void onMenuOpened(MenuOpened event)
+	{
+		MenuEntry[] entries = event.getMenuEntries();
+		clueInventoryManager.addHighlightWidgetSubmenus(entries, cluePreferenceManager);
 	}
 
 	@Subscribe

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -113,6 +113,9 @@ public class ClueDetailsPlugin extends Plugin
 	private ClueDetailsItemsOverlay itemsOverlay;
 
 	@Inject
+	private ClueDetailsWidgetsOverlay widgetsOverlay;
+
+	@Inject
 	private EventBus eventBus;
 
 	@Inject
@@ -193,6 +196,7 @@ public class ClueDetailsPlugin extends Plugin
 		eventBus.register(groundOverlay);
 
 		overlayManager.add(tagsOverlay);
+		overlayManager.add(widgetsOverlay);
 
 		overlayManager.add(inventoryOverlay);
 		eventBus.register(inventoryOverlay);
@@ -214,6 +218,7 @@ public class ClueDetailsPlugin extends Plugin
 		groundOverlay.startUp(clueGroundManager);
 		inventoryOverlay.setClueInventoryManager(clueInventoryManager);
 		itemsOverlay.setClueInventoryManager(clueInventoryManager);
+		widgetsOverlay.startUp(clueInventoryManager);
 
 		final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "/icon.png");
 

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -112,6 +112,7 @@ public class ClueDetailsPlugin extends Plugin
 	@Inject
 	private ClueDetailsItemsOverlay itemsOverlay;
 
+	@Getter
 	@Inject
 	private ClueDetailsWidgetsOverlay widgetsOverlay;
 
@@ -218,7 +219,7 @@ public class ClueDetailsPlugin extends Plugin
 		groundOverlay.startUp(clueGroundManager);
 		inventoryOverlay.setClueInventoryManager(clueInventoryManager);
 		itemsOverlay.setClueInventoryManager(clueInventoryManager);
-		widgetsOverlay.startUp(clueInventoryManager);
+		widgetsOverlay.startUp(clueInventoryManager, cluePreferenceManager);
 
 		final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "/icon.png");
 
@@ -415,11 +416,6 @@ public class ClueDetailsPlugin extends Plugin
 			infoOverlay.refreshHighlights();
 		}
 
-		if (event.getGroup().equals(config.CLUE_WIDGETS_CONFIG))
-		{
-			widgetsOverlay.refreshWidgets();
-		}
-
 		if (event.getKey().equals("beginnerDetails")
 			|| event.getKey().equals("easyDetails")
 			|| event.getKey().equals("mediumDetails")
@@ -428,6 +424,7 @@ public class ClueDetailsPlugin extends Plugin
 			|| event.getKey().equals("masterDetails"))
 		{
 			Clues.rebuildFilteredCluesCache();
+			widgetsOverlay.populateInventoryCluesWidgetColors();
 		}
 
 		if (event.getGroup().equals("clue-details-color")
@@ -437,6 +434,15 @@ public class ClueDetailsPlugin extends Plugin
 			|| event.getKey().equals("colorInventoryClueItems"))
 		{
 			itemsOverlay.invalidateCache();
+		}
+
+		if (event.getGroup().equals(config.CLUE_WIDGETS_CONFIG)
+			|| event.getKey().equals("highlightInventoryClueWidgets")
+			|| event.getKey().equals("widgetHighlightColor")
+			|| event.getKey().equals("colorInventoryClueWidgets")
+			|| event.getGroup().equals("clue-details-color"))
+		{
+			widgetsOverlay.populateInventoryCluesWidgetColors();
 		}
 
 		if (!event.getGroup().equals(ClueDetailsConfig.class.getAnnotation(ConfigGroup.class).value()))

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -259,6 +259,8 @@ public class ClueDetailsPlugin extends Plugin
 		overlayManager.remove(itemsOverlay);
 		eventBus.unregister(itemsOverlay);
 
+		overlayManager.remove(widgetsOverlay);
+
 		clientToolbar.removeNavigation(navButton);
 
 		clueGroundManager.saveStateToConfig();

--- a/src/main/java/com/cluedetails/ClueDetailsSharingManager.java
+++ b/src/main/java/com/cluedetails/ClueDetailsSharingManager.java
@@ -268,7 +268,7 @@ public class ClueDetailsSharingManager
 				}
 				else
 				{
-					configManager.setConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(importPoint.id), importPoint.widgetIds);
+					configManager.setConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(importPoint.id), gson.toJson(importPoint.widgetIds));
 				}
 			}
 		}

--- a/src/main/java/com/cluedetails/ClueDetailsSharingManager.java
+++ b/src/main/java/com/cluedetails/ClueDetailsSharingManager.java
@@ -112,8 +112,8 @@ public class ClueDetailsSharingManager
 					? gson.fromJson(clueItems, new TypeToken<List<Integer>>(){}.getType())
 					: null;
 
-			List<Integer> loadedClueWidgetsData = clueWidgets != null
-					? gson.fromJson(clueWidgets, new TypeToken<List<Integer>>(){}.getType())
+			List<WidgetId> loadedClueWidgetsData = clueWidgets != null
+					? gson.fromJson(clueWidgets, new TypeToken<List<WidgetId>>(){}.getType())
 					: null;
 
 			Color exportedColor = clueColor != null ? Color.decode(clueColor) : null;

--- a/src/main/java/com/cluedetails/ClueDetailsSharingManager.java
+++ b/src/main/java/com/cluedetails/ClueDetailsSharingManager.java
@@ -25,6 +25,8 @@
 package com.cluedetails;
 
 import static com.cluedetails.ClueDetailsConfig.CLUE_ITEMS_CONFIG;
+import static com.cluedetails.ClueDetailsConfig.CLUE_WIDGETS_CONFIG;
+
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.Runnables;
 import com.google.gson.Gson;
@@ -82,10 +84,13 @@ public class ClueDetailsSharingManager
 		{
 			int id = clue.getClueID();
 			configManager.unsetConfiguration("clue-details-text", String.valueOf(id));
+			configManager.unsetConfiguration("clue-details-color", String.valueOf(id));
+			configManager.unsetConfiguration(CLUE_ITEMS_CONFIG, String.valueOf(id));
+			configManager.unsetConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(id));
 		}
 	}
 
-	public void exportClueDetails(boolean exportText, boolean exportColors, boolean exportItems)
+	public void exportClueDetails(boolean exportText, boolean exportColors, boolean exportItems, boolean exportWidgets)
 	{
 		List<ClueIdToDetails> clueIdToDetailsList = new ArrayList<>();
 
@@ -97,77 +102,26 @@ public class ClueDetailsSharingManager
 		for (Clues clue : filteredClues)
 		{
 			int id = clue.getClueID();
-			String clueText = configManager.getConfiguration("clue-details-text", String.valueOf(id));
-			String clueColor = configManager.getConfiguration("clue-details-color", String.valueOf(id));
-			String clueItems = configManager.getConfiguration(CLUE_ITEMS_CONFIG, String.valueOf(id));
+			String clueText = exportText ? configManager.getConfiguration("clue-details-text", String.valueOf(id)) : null;
+			String clueColor = exportColors ? configManager.getConfiguration("clue-details-color", String.valueOf(id)) : null;
+			String clueItems = exportItems ? configManager.getConfiguration(CLUE_ITEMS_CONFIG, String.valueOf(id)) : null;
+			String clueWidgets = exportWidgets ? configManager.getConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(id)) : null;
 
 			// Try to export text, color, and items. Export where valid configurations are returned
-			if (exportText && exportColors && exportItems)
-			{
-				if (clueItems != null)
-				{
-					List<Integer> loadedClueItemsData = gson.fromJson(clueItems, new TypeToken<List<Integer>>()
-					{
-					}.getType());
+			List<Integer> loadedClueItemsData = clueItems != null
+					? gson.fromJson(clueItems, new TypeToken<List<Integer>>(){}.getType())
+					: null;
 
-					// Export text, colors, and items
-					if (clueColor != null && clueText != null)
-					{
-						clueIdToDetailsList.add(new ClueIdToDetails(id, clueText, Color.decode(clueColor), loadedClueItemsData));
-					}
-					// Export text and items
-					else if (clueText != null)
-					{
-						clueIdToDetailsList.add(new ClueIdToDetails(id, clueText, loadedClueItemsData));
-					}
-					// Export color and items
-					else if (clueColor != null)
-					{
-						clueIdToDetailsList.add(new ClueIdToDetails(id, Color.decode(clueColor), loadedClueItemsData));
-					}
-					// Export items
-					else
-					{
-						clueIdToDetailsList.add(new ClueIdToDetails(id, loadedClueItemsData));
-					}
-				}
-				else
-				{
-					// Export text and colors
-					if (clueText != null && clueColor != null)
-					{
-						clueIdToDetailsList.add(new ClueIdToDetails(id, clueText, Color.decode(clueColor)));
-					}
-					// Export text
-					else if (clueText != null)
-					{
-						clueIdToDetailsList.add(new ClueIdToDetails(id, clueText));
-					}
-					// Export colors
-					else if (clueColor != null)
-					{
-						clueIdToDetailsList.add(new ClueIdToDetails(id, Color.decode(clueColor)));
-					}
-				}
-			}
-			// Export text
-			else if (exportText && clueText != null)
-			{
-				clueIdToDetailsList.add(new ClueIdToDetails(id, clueText));
-			}
-			// Export colors
-			else if (exportColors && clueColor != null)
-			{
-				clueIdToDetailsList.add(new ClueIdToDetails(id, Color.decode(clueColor)));
-			}
-			// Export items
-			else if (exportItems && clueItems != null)
-			{
-				List<Integer> loadedClueItemsData = gson.fromJson(clueItems, new TypeToken<List<Integer>>()
-				{
-				}.getType());
+			List<Integer> loadedClueWidgetsData = clueWidgets != null
+					? gson.fromJson(clueWidgets, new TypeToken<List<Integer>>(){}.getType())
+					: null;
 
-				clueIdToDetailsList.add(new ClueIdToDetails(id, loadedClueItemsData));
+			Color exportedColor = clueColor != null ? Color.decode(clueColor) : null;
+
+			ClueIdToDetails clueDetails = new ClueIdToDetails(id, clueText, exportedColor, loadedClueItemsData, loadedClueWidgetsData);
+			if (clueText != null || exportedColor != null || loadedClueItemsData != null || loadedClueWidgetsData != null)
+			{
+				clueIdToDetailsList.add(clueDetails);
 			}
 		}
 
@@ -299,11 +253,22 @@ public class ClueDetailsSharingManager
 			{
 				if (importPoint.itemIds.isEmpty())
 				{
-					configManager.unsetConfiguration("clue-details-items", String.valueOf(importPoint.id));
+					configManager.unsetConfiguration(CLUE_ITEMS_CONFIG, String.valueOf(importPoint.id));
 				}
 				else
 				{
-					configManager.setConfiguration("clue-details-items", String.valueOf(importPoint.id), importPoint.itemIds);
+					configManager.setConfiguration(CLUE_ITEMS_CONFIG, String.valueOf(importPoint.id), importPoint.itemIds);
+				}
+			}
+			if (importPoint.widgetIds != null)
+			{
+				if (importPoint.widgetIds.isEmpty())
+				{
+					configManager.unsetConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(importPoint.id));
+				}
+				else
+				{
+					configManager.setConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(importPoint.id), importPoint.widgetIds);
 				}
 			}
 		}

--- a/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
@@ -64,6 +64,11 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 		this.clueInventoryManager = clueInventoryManager;
 	}
 
+	public void refreshWidgets()
+	{
+		this.clueInventoryManager.updateInventoryCluesWidgetIds();
+	}
+
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{

--- a/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2024, Zoinkwiz <https://www.github.com/Zoinkwiz>
+ * Copyright (c) 2017, Aria <aria@ar1as.space>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.cluedetails;
+
+import net.runelite.api.Client;
+import net.runelite.api.Point;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.geom.Area;
+import java.util.*;
+
+public class ClueDetailsWidgetsOverlay extends OverlayPanel
+{
+	private final Client client;
+	private final ClueDetailsConfig config;
+
+	private ClueInventoryManager clueInventoryManager;
+
+	@Inject
+	public ClueDetailsWidgetsOverlay(Client client, ClueDetailsConfig config)
+	{
+		setPriority(PRIORITY_HIGHEST);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		setDragTargetable(false);
+		setPosition(OverlayPosition.DYNAMIC);
+
+		this.client = client;
+		this.config = config;
+	}
+
+	public void startUp(ClueInventoryManager clueInventoryManager)
+	{
+		this.clueInventoryManager = clueInventoryManager;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (config.colorInventoryClueWidgets())
+		{
+			Set<Integer> clueWidgetIds = clueInventoryManager.getClueWidgetIds();
+			if (!clueWidgetIds.isEmpty())
+			{
+				Color originalColor = graphics.getColor();
+				graphics.setColor(config.widgetHighlightColor());
+				for (int widgetId : clueWidgetIds)
+				{
+					Widget widget = client.getWidget(widgetId);
+					if (widget == null || widget.isHidden())
+					{
+						continue;
+					}
+
+					// Highlight as much of the widget as is visible of it inside its parent
+					Widget parent = widget.getParent();
+					if (parent != null)
+					{
+						Point widgetLocation = widget.getCanvasLocation();
+						if (widgetLocation == null)
+						{
+							continue;
+						}
+
+						Point parentLocation = parent.getCanvasLocation();
+						if (parentLocation.getY() > widgetLocation.getY() + widget.getHeight()
+							|| parentLocation.getY() + parent.getHeight() < widgetLocation.getY())
+						{
+							continue;
+						}
+
+						int x = widgetLocation.getX(); // no horizontal scrolling affecting location
+						int y = Math.max(widgetLocation.getY(), parentLocation.getY());
+						int width = widget.getWidth(); // no horizontal scrolling affecting width
+						int height = Math.min(widget.getHeight(), parent.getHeight());
+
+						Area widgetArea = new Area(new Rectangle(x, y, width, height));
+						graphics.fill(widgetArea);
+					}
+					else
+					{
+						graphics.fill(widget.getBounds());
+					}
+				}
+				graphics.setColor(originalColor);
+			}
+		}
+
+		return super.render(graphics);
+	}
+}

--- a/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
@@ -106,7 +106,8 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 					List<WidgetId> widgetsPreference = cluePreferenceManager.getWidgetsPreference(clueId);
 					if (widgetsPreference != null)
 					{
-						for (WidgetId widgetId : widgetsPreference) {
+						for (WidgetId widgetId : widgetsPreference)
+						{
 							clueWidgetColors.put(widgetId, widgetColor);
 						}
 					}
@@ -126,12 +127,12 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 			{
 				WidgetId widgetId = entry.getKey();
 				int componentId = widgetId.getComponentId();
-				int childIndex = widgetId.getChildIndex();
+				Integer childIndex = widgetId.getChildIndex();
 				Color widgetColor = entry.getValue();
 
 				Widget widget = client.getWidget(componentId);
 
-				if (widget != null && childIndex != -1)
+				if (widget != null && childIndex != null && childIndex != -1)
 				{
 					Widget[] children = widget.getChildren();
 					if (children != null && childIndex < children.length)

--- a/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
@@ -145,7 +145,8 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 				}
 
 				// parent is set earlier for child widgets but if not, use the normal widget's parent
-				if (parentWidget == null) {
+				if (parentWidget == null)
+				{
                     parentWidget = widget.getParent();
 				}
 

--- a/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2024, Zoinkwiz <https://www.github.com/Zoinkwiz>
- * Copyright (c) 2017, Aria <aria@ar1as.space>
+ * Copyright (c) 2025, cubeee <https://www.github.com/cubeee>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
@@ -50,6 +50,8 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 
 	private final Cache<WidgetId, Color> clueColorCache;
 
+	private long lastUpdate = Integer.MAX_VALUE;
+
 	@Inject
 	public ClueDetailsWidgetsOverlay(Client client, ClueDetailsConfig config, ConfigManager configManager)
 	{
@@ -74,7 +76,7 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 		this.cluePreferenceManager = cluePreferenceManager;
 	}
 
-	public void populateInventoryCluesWidgetColors()
+	public void cacheInventoryCluesWidgetColors()
 	{
 		Color defaultHighlightColor = config.widgetHighlightColor();
 		Map<WidgetId, Color> clueWidgetColors = new HashMap<>();
@@ -117,6 +119,13 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		long lastInventoryUpdate = clueInventoryManager.getLastInventoryUpdate();
+		if (lastUpdate != lastInventoryUpdate)
+		{
+			lastUpdate = lastInventoryUpdate;
+			cacheInventoryCluesWidgetColors();
+		}
+
 		if (config.highlightInventoryClueWidgets() && clueColorCache.size() > 0)
 		{
 			for (Map.Entry<WidgetId, Color> entry : clueColorCache.asMap().entrySet())

--- a/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
@@ -52,7 +52,7 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 	private ClueInventoryManager clueInventoryManager;
 	private CluePreferenceManager cluePreferenceManager;
 
-	private final Cache<Integer, Color> clueColorCache;
+	private final Cache<WidgetId, Color> clueColorCache;
 
 	@Inject
 	public ClueDetailsWidgetsOverlay(Client client, ClueDetailsConfig config, ConfigManager configManager)
@@ -81,7 +81,7 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 	public void populateInventoryCluesWidgetColors()
 	{
 		Color defaultHighlightColor = config.widgetHighlightColor();
-		Map<Integer, Color> clueWidgetColors = new HashMap<>();
+		Map<WidgetId, Color> clueWidgetColors = new HashMap<>();
 		if (config.highlightInventoryClueWidgets())
 		{
 			for (Integer itemID : clueInventoryManager.getCluesInInventory())
@@ -103,10 +103,10 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 					Color widgetColor = config.colorInventoryClueWidgets()
 						? new Color(clueColor.getRed(), clueColor.getGreen(), clueColor.getBlue(), defaultHighlightColor.getAlpha())
 						: defaultHighlightColor;
-					List<Integer> widgetsPreference = cluePreferenceManager.getWidgetsPreference(clueId);
+					List<WidgetId> widgetsPreference = cluePreferenceManager.getWidgetsPreference(clueId);
 					if (widgetsPreference != null)
 					{
-						for (int widgetId : widgetsPreference) {
+						for (WidgetId widgetId : widgetsPreference) {
 							clueWidgetColors.put(widgetId, widgetColor);
 						}
 					}
@@ -122,12 +122,24 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 	{
 		if (config.highlightInventoryClueWidgets() && clueColorCache.size() > 0)
 		{
-			for (Map.Entry<Integer, Color> entry : clueColorCache.asMap().entrySet())
+			for (Map.Entry<WidgetId, Color> entry : clueColorCache.asMap().entrySet())
 			{
-				int widgetId = entry.getKey();
+				WidgetId widgetId = entry.getKey();
+				int componentId = widgetId.getComponentId();
+				int childIndex = widgetId.getChildIndex();
 				Color widgetColor = entry.getValue();
 
-				Widget widget = client.getWidget(widgetId);
+				Widget widget = client.getWidget(componentId);
+
+				if (widget != null && childIndex != -1)
+				{
+					Widget[] children = widget.getChildren();
+					if (children != null && childIndex < children.length)
+					{
+						widget = children[childIndex];
+					}
+				}
+
 				if (widget == null || widget.isHidden())
 				{
 					continue;

--- a/src/main/java/com/cluedetails/ClueIdToDetails.java
+++ b/src/main/java/com/cluedetails/ClueIdToDetails.java
@@ -35,52 +35,15 @@ public class ClueIdToDetails
 	String text;
 	Color color;
 	List<Integer> itemIds;
+	List<Integer> widgetIds;
 
-	public ClueIdToDetails(int id, String text)
-	{
-		this.id = id;
-		this.text = text;
-	}
-
-	public ClueIdToDetails(int id, Color color)
-	{
-		this.id = id;
-		this.color = color;
-	}
-
-	public ClueIdToDetails(int id, List<Integer> itemIds)
-	{
-		this.id = id;
-		this.itemIds = itemIds;
-	}
-
-	public ClueIdToDetails(int id, String text, Color color)
-	{
-		this.id = id;
-		this.text = text;
-		this.color = color;
-	}
-
-	public ClueIdToDetails(int id, String text, List<Integer> itemIds)
-	{
-		this.id = id;
-		this.text = text;
-		this.itemIds = itemIds;
-	}
-
-	public ClueIdToDetails(int id, Color color, List<Integer> itemIds)
-	{
-		this.id = id;
-		this.color = color;
-		this.itemIds = itemIds;
-	}
-
-	public ClueIdToDetails(int id, String text, Color color, List<Integer> itemIds)
+	public ClueIdToDetails(int id, String text, Color color, List<Integer> itemIds, List<Integer> widgetIds)
 	{
 		this.id = id;
 		this.text = text;
 		this.color = color;
 		this.itemIds = itemIds;
+		this.widgetIds = widgetIds;
 	}
 
 	public static boolean equalRGB(Color color1, Color color2)

--- a/src/main/java/com/cluedetails/ClueIdToDetails.java
+++ b/src/main/java/com/cluedetails/ClueIdToDetails.java
@@ -35,9 +35,9 @@ public class ClueIdToDetails
 	String text;
 	Color color;
 	List<Integer> itemIds;
-	List<Integer> widgetIds;
+	List<WidgetId> widgetIds;
 
-	public ClueIdToDetails(int id, String text, Color color, List<Integer> itemIds, List<Integer> widgetIds)
+	public ClueIdToDetails(int id, String text, Color color, List<Integer> itemIds, List<WidgetId> widgetIds)
 	{
 		this.id = id;
 		this.text = text;

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -240,7 +240,7 @@ public class ClueInventoryManager
 
 			int componentId = widget.getId();
 			int childIndex = widget.getIndex();
-			WidgetId widgetId = new WidgetId(componentId, childIndex);
+			WidgetId widgetId = new WidgetId(componentId, childIndex == -1 ? null : childIndex);
 
 			MenuEntry clueDetailsEntry = client.getMenu().createMenuEntry(1) // place above Cancel
 					.setOption("Clue details")

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -210,48 +210,6 @@ public class ClueInventoryManager
 		return cluesInInventory.get(clueItemID);
 	}
 
-	public void addHighlightWidgetSubmenus(MenuEntry[] entries, CluePreferenceManager cluePreferenceManager)
-	{
-		if (!client.isKeyPressed(KeyCode.KC_SHIFT))
-		{
-			return;
-		}
-
-		if (cluesInInventory.isEmpty())
-		{
-			return;
-		}
-
-		for (int idx = entries.length - 1; idx >= 0; --idx)
-		{
-			MenuEntry entry = entries[idx];
-
-			Widget widget = entry.getWidget();
-			if (widget == null || widget.getActions() == null)
-			{
-				return;
-			}
-
-			// Disable item marking, separate feature
-			if (widget.getItemId() != -1)
-			{
-				continue;
-			}
-
-			int componentId = widget.getId();
-			int childIndex = widget.getIndex();
-			WidgetId widgetId = new WidgetId(componentId, childIndex == -1 ? null : childIndex);
-
-			MenuEntry clueDetailsEntry = client.getMenu().createMenuEntry(1) // place above Cancel
-					.setOption("Clue details")
-					.setType(MenuAction.RUNELITE);
-			Menu submenu = clueDetailsEntry.createSubMenu();
-
-			cluesInInventory.forEach((id, instance) -> instance.getClueIds().forEach((clueId) -> addHighlightWidgetMenu(cluePreferenceManager, submenu, Clues.forClueIdFiltered(clueId), widgetId)));
-			break;
-		}
-	}
-
 	public void onMenuEntryAdded(MenuEntryAdded event, CluePreferenceManager cluePreferenceManager, ClueDetailsParentPanel panel)
 	{
 		MenuEntry entry = event.getMenuEntry();
@@ -422,23 +380,6 @@ public class ClueInventoryManager
 				updateClueItems(clue, itemId, cluePreferenceManager));
 	}
 
-	private void addHighlightWidgetMenu(CluePreferenceManager cluePreferenceManager, Menu menu, Clues clue, WidgetId widgetId)
-	{
-		if (clue == null) return;
-
-		boolean widgetInCluePreference = cluePreferenceManager.widgetsPreferenceContainsWidget(clue.getClueID(), widgetId);
-
-		String action = widgetInCluePreference ? "Remove from " : "Add to ";
-		String clueDetail = clue.getDetail(configManager);
-		final String text = action + "'" + clueDetail + "'";
-
-		// Add menu to widget for clue
-		menu.createMenuEntry(-1)
-				.setOption(text)
-				.setType(MenuAction.RUNELITE)
-				.onClick(e -> updateClueWidgets(clue, widgetId, cluePreferenceManager));
-	}
-
 	private void toggleMarkClue(CluePreferenceManager cluePreferenceManager, ClueDetailsParentPanel panel, int clueId, boolean isMarked, String target)
 	{
 		// We don't want to have marking on masters I think
@@ -479,32 +420,6 @@ public class ClueInventoryManager
 
 		// Save Clue itemIds
 		cluePreferenceManager.saveItemsPreference(clueId, clueItemIds);
-	}
-
-	private void updateClueWidgets(Clues clue, WidgetId widgetId, CluePreferenceManager cluePreferenceManager)
-	{
-		// Get existing Clue widgetIds
-		int clueId = clue.getClueID();
-		List<WidgetId> clueWidgetIds = cluePreferenceManager.getWidgetsPreference(clueId);
-
-		if (clueWidgetIds == null)
-		{
-			clueWidgetIds = new ArrayList<>();
-		}
-
-		// Remove if already present
-		if (clueWidgetIds.contains(widgetId))
-		{
-			clueWidgetIds.remove(widgetId);
-		}
-		// Add if not present
-		else
-		{
-			clueWidgetIds.add(widgetId);
-		}
-
-		// Save Clue widgetIds
-		cluePreferenceManager.saveWidgetsPreference(clueId, clueWidgetIds);
 	}
 
 	private boolean hasClueName(String name)

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -113,7 +113,7 @@ public class ClueInventoryManager
 		updateInventoryCluesWidgetIds();
 	}
 
-	private void updateInventoryCluesWidgetIds()
+	public void updateInventoryCluesWidgetIds()
 	{
 		Set<Integer> clueWidgetIds = new HashSet<>();
 		for (ClueInstance instance : cluesInInventory.values())

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -26,9 +26,9 @@ package com.cluedetails;
 
 import com.cluedetails.panels.ClueDetailsParentPanel;
 
-import java.awt.Color;
 import java.util.*;
 import javax.inject.Singleton;
+
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -239,13 +239,15 @@ public class ClueInventoryManager
 			}
 
 			int componentId = widget.getId();
+			int childIndex = widget.getIndex();
+			WidgetId widgetId = new WidgetId(componentId, childIndex);
 
 			MenuEntry clueDetailsEntry = client.getMenu().createMenuEntry(1) // place above Cancel
 					.setOption("Clue details")
 					.setType(MenuAction.RUNELITE);
 			Menu submenu = clueDetailsEntry.createSubMenu();
 
-			cluesInInventory.forEach((id, instance) -> instance.getClueIds().forEach((clueId) -> addHighlightWidgetMenu(cluePreferenceManager, submenu, Clues.forClueIdFiltered(clueId), componentId)));
+			cluesInInventory.forEach((id, instance) -> instance.getClueIds().forEach((clueId) -> addHighlightWidgetMenu(cluePreferenceManager, submenu, Clues.forClueIdFiltered(clueId), widgetId)));
 			break;
 		}
 	}
@@ -420,7 +422,7 @@ public class ClueInventoryManager
 				updateClueItems(clue, itemId, cluePreferenceManager));
 	}
 
-	private void addHighlightWidgetMenu(CluePreferenceManager cluePreferenceManager, Menu menu, Clues clue, int widgetId)
+	private void addHighlightWidgetMenu(CluePreferenceManager cluePreferenceManager, Menu menu, Clues clue, WidgetId widgetId)
 	{
 		if (clue == null) return;
 
@@ -479,11 +481,11 @@ public class ClueInventoryManager
 		cluePreferenceManager.saveItemsPreference(clueId, clueItemIds);
 	}
 
-	private void updateClueWidgets(Clues clue, int widgetId, CluePreferenceManager cluePreferenceManager)
+	private void updateClueWidgets(Clues clue, WidgetId widgetId, CluePreferenceManager cluePreferenceManager)
 	{
 		// Get existing Clue widgetIds
 		int clueId = clue.getClueID();
-		List<Integer> clueWidgetIds = cluePreferenceManager.getWidgetsPreference(clueId);
+		List<WidgetId> clueWidgetIds = cluePreferenceManager.getWidgetsPreference(clueId);
 
 		if (clueWidgetIds == null)
 		{
@@ -493,7 +495,7 @@ public class ClueInventoryManager
 		// Remove if already present
 		if (clueWidgetIds.contains(widgetId))
 		{
-			clueWidgetIds.remove(Integer.valueOf(widgetId));
+			clueWidgetIds.remove(widgetId);
 		}
 		// Add if not present
 		else

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -29,6 +29,7 @@ import com.cluedetails.panels.ClueDetailsParentPanel;
 import java.util.*;
 import javax.inject.Singleton;
 
+import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -61,6 +62,9 @@ public class ClueInventoryManager
 	private final Map<Integer, ClueInstance> cluesInInventory = new HashMap<>();
 	private final Map<Integer, ClueInstance> previousCluesInInventory = new HashMap<>();
 
+	@Getter
+	private long lastInventoryUpdate = 0;
+
 	// To be initialized to avoid passing around
 	@Setter
 	public static ClueDetailsConfig config;
@@ -74,6 +78,11 @@ public class ClueInventoryManager
 		this.clueGroundManager = clueGroundManager;
 		this.clueBankManager = clueBankManager;
 		this.chatboxPanelManager = chatboxPanelManager;
+	}
+
+	public void updateLastInventoryRefreshTime()
+	{
+		this.lastInventoryUpdate = System.currentTimeMillis();
 	}
 
 	public void updateInventory(ItemContainer inventoryContainer)
@@ -110,7 +119,7 @@ public class ClueInventoryManager
 			}
 		}
 
-		clueDetailsPlugin.getWidgetsOverlay().populateInventoryCluesWidgetColors();
+		clueDetailsPlugin.getClueInventoryManager().updateLastInventoryRefreshTime();
 	}
 
 	private void checkItemAsClueInstance(int itemId)
@@ -182,6 +191,7 @@ public class ClueInventoryManager
 			if (clueInfo == null) continue;
 			if (!Objects.equals(clueInfo.getItemID(), itemID)) continue;
 			clueInstance.setClueIds(clueIds);
+			clueDetailsPlugin.getClueInventoryManager().updateLastInventoryRefreshTime();
 			break;
 		}
 	}
@@ -198,6 +208,7 @@ public class ClueInventoryManager
 		ClueInstance beginnerClueInInv = cluesInInventory.get(ItemID.CLUE_SCROLL_BEGINNER);
 		if (beginnerClueInInv == null) return;
 		beginnerClueInInv.setClueIds(clueIds);
+		clueDetailsPlugin.getClueInventoryManager().updateLastInventoryRefreshTime();
 	}
 
 	public Set<Integer> getCluesInInventory()
@@ -445,6 +456,7 @@ public class ClueInventoryManager
 			if (clue == null) return;
 			clue.setClueIds(List.of());
 			clueDetailsPlugin.getItemsOverlay().invalidateCache();
+			clueDetailsPlugin.getClueInventoryManager().updateLastInventoryRefreshTime();
 		}
 		else if (isNewMasterClue(chatDialogClueItemWidget)
 			|| (isUriMasterClue(headModelWidget) && isUriStandardDialogue(npcChatWidget)))
@@ -453,6 +465,7 @@ public class ClueInventoryManager
 			if (clue == null) return;
 			clue.setClueIds(List.of());
 			clueDetailsPlugin.getItemsOverlay().invalidateCache();
+			clueDetailsPlugin.getClueInventoryManager().updateLastInventoryRefreshTime();
 		}
 	}
 

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -26,6 +26,7 @@ package com.cluedetails;
 
 import com.cluedetails.panels.ClueDetailsParentPanel;
 
+import java.awt.Color;
 import java.util.*;
 import javax.inject.Singleton;
 import lombok.Setter;
@@ -59,7 +60,6 @@ public class ClueInventoryManager
 	private final ChatboxPanelManager chatboxPanelManager;
 	private final Map<Integer, ClueInstance> cluesInInventory = new HashMap<>();
 	private final Map<Integer, ClueInstance> previousCluesInInventory = new HashMap<>();
-	private final Set<Integer> inventoryCluesWidgetIds = new HashSet<>();
 
 	// To be initialized to avoid passing around
 	@Setter
@@ -110,34 +110,7 @@ public class ClueInventoryManager
 			}
 		}
 
-		updateInventoryCluesWidgetIds();
-	}
-
-	public void updateInventoryCluesWidgetIds()
-	{
-		Set<Integer> clueWidgetIds = new HashSet<>();
-		for (ClueInstance instance : cluesInInventory.values())
-		{
-			if (instance == null)
-			{
-				continue;
-			}
-			for (int clueId : instance.getClueIds())
-			{
-				List<Integer> widgetsPreference = clueDetailsPlugin.getCluePreferenceManager().getWidgetsPreference(clueId);
-				if (widgetsPreference != null)
-				{
-					clueWidgetIds.addAll(widgetsPreference);
-				}
-			}
-		}
-		inventoryCluesWidgetIds.clear();
-		inventoryCluesWidgetIds.addAll(clueWidgetIds);
-	}
-
-	public Set<Integer> getClueWidgetIds()
-	{
-		return inventoryCluesWidgetIds;
+		clueDetailsPlugin.getWidgetsOverlay().populateInventoryCluesWidgetColors();
 	}
 
 	private void checkItemAsClueInstance(int itemId)
@@ -530,9 +503,6 @@ public class ClueInventoryManager
 
 		// Save Clue widgetIds
 		cluePreferenceManager.saveWidgetsPreference(clueId, clueWidgetIds);
-
-		// Reload highlighted widget ids for clues in inventory
-		updateInventoryCluesWidgetIds();
 	}
 
 	private boolean hasClueName(String name)

--- a/src/main/java/com/cluedetails/CluePreferenceManager.java
+++ b/src/main/java/com/cluedetails/CluePreferenceManager.java
@@ -84,9 +84,9 @@ public class CluePreferenceManager
 		}
 	}
 
-	public boolean widgetsPreferenceContainsWidget(int clueID, int widgetId)
+	public boolean widgetsPreferenceContainsWidget(int clueID, WidgetId widgetId)
 	{
-		List<Integer> clueWidgetIds = getWidgetsPreference(clueID);
+		List<WidgetId> clueWidgetIds = getWidgetsPreference(clueID);
 
 		if (clueWidgetIds != null)
 		{
@@ -95,14 +95,14 @@ public class CluePreferenceManager
 		return false;
 	}
 
-	public List<Integer> getWidgetsPreference(int clueID)
+	public List<WidgetId> getWidgetsPreference(int clueID)
 	{
 		String clueWidgets = configManager.getConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(clueID));
 
-		return clueDetailsPlugin.gson.fromJson(clueWidgets, new TypeToken<List<Integer>>(){}.getType());
+		return clueDetailsPlugin.gson.fromJson(clueWidgets, new TypeToken<List<WidgetId>>(){}.getType());
 	}
 
-	public void saveWidgetsPreference(int clueID, List<Integer> newWidgets)
+	public void saveWidgetsPreference(int clueID, List<WidgetId> newWidgets)
 	{
 		if (newWidgets.isEmpty())
 		{

--- a/src/main/java/com/cluedetails/CluePreferenceManager.java
+++ b/src/main/java/com/cluedetails/CluePreferenceManager.java
@@ -25,6 +25,8 @@
 package com.cluedetails;
 
 import static com.cluedetails.ClueDetailsConfig.CLUE_ITEMS_CONFIG;
+import static com.cluedetails.ClueDetailsConfig.CLUE_WIDGETS_CONFIG;
+
 import com.google.gson.reflect.TypeToken;
 import java.util.List;
 import net.runelite.client.config.ConfigManager;
@@ -79,6 +81,37 @@ public class CluePreferenceManager
 		{
 			String clueItemIdsJson = clueDetailsPlugin.gson.toJson(newItems);
 			configManager.setConfiguration(CLUE_ITEMS_CONFIG, String.valueOf(clueID), clueItemIdsJson);
+		}
+	}
+
+	public boolean widgetsPreferenceContainsWidget(int clueID, int widgetId)
+	{
+		List<Integer> clueWidgetIds = getWidgetsPreference(clueID);
+
+		if (clueWidgetIds != null)
+		{
+			return clueWidgetIds.contains(widgetId);
+		}
+		return false;
+	}
+
+	public List<Integer> getWidgetsPreference(int clueID)
+	{
+		String clueWidgets = configManager.getConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(clueID));
+
+		return clueDetailsPlugin.gson.fromJson(clueWidgets, new TypeToken<List<Integer>>(){}.getType());
+	}
+
+	public void saveWidgetsPreference(int clueID, List<Integer> newWidgets)
+	{
+		if (newWidgets.isEmpty())
+		{
+			configManager.unsetConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(clueID));
+		}
+		else
+		{
+			String clueWidgetIdsJson = clueDetailsPlugin.gson.toJson(newWidgets);
+			configManager.setConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(clueID), clueWidgetIdsJson);
 		}
 	}
 }

--- a/src/main/java/com/cluedetails/CluePreferenceManager.java
+++ b/src/main/java/com/cluedetails/CluePreferenceManager.java
@@ -29,6 +29,8 @@ import static com.cluedetails.ClueDetailsConfig.CLUE_WIDGETS_CONFIG;
 
 import com.google.gson.reflect.TypeToken;
 import java.util.List;
+import java.util.stream.*;
+
 import net.runelite.client.config.ConfigManager;
 
 public class CluePreferenceManager
@@ -110,7 +112,11 @@ public class CluePreferenceManager
 		}
 		else
 		{
-			String clueWidgetIdsJson = clueDetailsPlugin.gson.toJson(newWidgets);
+			List<WidgetId> mappedWidgetIds = newWidgets
+				.stream()
+				.map(w -> new WidgetId(w.getComponentId(), w.getChildIndex() == null || w.getChildIndex() == -1 ? null : w.getChildIndex()))
+				.collect(Collectors.toList());
+			String clueWidgetIdsJson = clueDetailsPlugin.gson.toJson(mappedWidgetIds);
 			configManager.setConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(clueID), clueWidgetIdsJson);
 		}
 	}

--- a/src/main/java/com/cluedetails/ClueWidgetManager.java
+++ b/src/main/java/com/cluedetails/ClueWidgetManager.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2025, cubeee <https://www.github.com/cubeee>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.cluedetails;
 
 import lombok.Setter;
@@ -70,7 +94,8 @@ public class ClueWidgetManager
             Menu submenu = clueDetailsEntry.createSubMenu();
 
             clueInventoryManager.getCluesInInventory()
-                    .forEach(itemId -> {
+                    .forEach(itemId ->
+                    {
                         ClueInstance instance = clueInventoryManager.getClueByClueItemId(itemId);
                         if (instance != null)
                         {

--- a/src/main/java/com/cluedetails/ClueWidgetManager.java
+++ b/src/main/java/com/cluedetails/ClueWidgetManager.java
@@ -72,7 +72,8 @@ public class ClueWidgetManager
             clueInventoryManager.getCluesInInventory()
                     .forEach(itemId -> {
                         ClueInstance instance = clueInventoryManager.getClueByClueItemId(itemId);
-                        if (instance != null) {
+                        if (instance != null)
+                        {
                             instance
                                 .getClueIds()
                                 .forEach((clueId) -> addHighlightWidgetMenu(cluePreferenceManager, submenu, Clues.forClueIdFiltered(clueId), widgetId));

--- a/src/main/java/com/cluedetails/ClueWidgetManager.java
+++ b/src/main/java/com/cluedetails/ClueWidgetManager.java
@@ -1,0 +1,128 @@
+package com.cluedetails;
+
+import lombok.Setter;
+import net.runelite.api.Client;
+import net.runelite.api.KeyCode;
+import net.runelite.api.Menu;
+import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.config.ConfigManager;
+
+import javax.inject.Singleton;
+import java.util.*;
+
+@Singleton
+public class ClueWidgetManager
+{
+    private final Client client;
+    private final ConfigManager configManager;
+    private final ClueInventoryManager clueInventoryManager;
+    private final CluePreferenceManager cluePreferenceManager;
+
+    public ClueWidgetManager(Client client, ConfigManager configManager, ClueInventoryManager clueInventoryManager, CluePreferenceManager cluePreferenceManager)
+    {
+        this.client = client;
+        this.configManager = configManager;
+        this.clueInventoryManager = clueInventoryManager;
+        this.cluePreferenceManager = cluePreferenceManager;
+    }
+
+    // To be initialized to avoid passing around
+    @Setter
+    public static ClueDetailsConfig config;
+
+    public void addHighlightWidgetSubmenus(MenuEntry[] entries)
+    {
+        if (!client.isKeyPressed(KeyCode.KC_SHIFT))
+        {
+            return;
+        }
+
+        if (clueInventoryManager.getCluesInInventory().isEmpty())
+        {
+            return;
+        }
+
+        for (int idx = entries.length - 1; idx >= 0; --idx)
+        {
+            MenuEntry entry = entries[idx];
+
+            Widget widget = entry.getWidget();
+            if (widget == null || widget.getActions() == null)
+            {
+                return;
+            }
+
+            // Disable item marking, separate feature
+            if (widget.getItemId() != -1)
+            {
+                continue;
+            }
+
+            int componentId = widget.getId();
+            int childIndex = widget.getIndex();
+            WidgetId widgetId = new WidgetId(componentId, childIndex == -1 ? null : childIndex);
+
+            MenuEntry clueDetailsEntry = client.getMenu().createMenuEntry(1) // place above Cancel
+                    .setOption("Clue details")
+                    .setType(MenuAction.RUNELITE);
+            Menu submenu = clueDetailsEntry.createSubMenu();
+
+            clueInventoryManager.getCluesInInventory()
+                    .forEach(itemId -> {
+                        ClueInstance instance = clueInventoryManager.getClueByClueItemId(itemId);
+                        if (instance != null) {
+                            instance
+                                .getClueIds()
+                                .forEach((clueId) -> addHighlightWidgetMenu(cluePreferenceManager, submenu, Clues.forClueIdFiltered(clueId), widgetId));
+                        }
+                    });
+            break;
+        }
+    }
+
+    private void addHighlightWidgetMenu(CluePreferenceManager cluePreferenceManager, Menu menu, Clues clue, WidgetId widgetId)
+    {
+        if (clue == null) return;
+
+        boolean widgetInCluePreference = cluePreferenceManager.widgetsPreferenceContainsWidget(clue.getClueID(), widgetId);
+
+        String action = widgetInCluePreference ? "Remove from " : "Add to ";
+        String clueDetail = clue.getDetail(configManager);
+        final String text = action + "'" + clueDetail + "'";
+
+        // Add menu to widget for clue
+        menu.createMenuEntry(-1)
+                .setOption(text)
+                .setType(MenuAction.RUNELITE)
+                .onClick(e -> updateClueWidgets(clue, widgetId, cluePreferenceManager));
+    }
+
+    private void updateClueWidgets(Clues clue, WidgetId widgetId, CluePreferenceManager cluePreferenceManager)
+    {
+        // Get existing Clue widgetIds
+        int clueId = clue.getClueID();
+        List<WidgetId> clueWidgetIds = cluePreferenceManager.getWidgetsPreference(clueId);
+
+        if (clueWidgetIds == null)
+        {
+            clueWidgetIds = new ArrayList<>();
+        }
+
+        // Remove if already present
+        if (clueWidgetIds.contains(widgetId))
+        {
+            clueWidgetIds.remove(widgetId);
+        }
+        // Add if not present
+        else
+        {
+            clueWidgetIds.add(widgetId);
+        }
+
+        // Save Clue widgetIds
+        cluePreferenceManager.saveWidgetsPreference(clueId, clueWidgetIds);
+    }
+
+}

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1218,18 +1218,6 @@ public class Clues
 		return null;
 	}
 
-	public List<Integer> getWidgets(ClueDetailsPlugin plugin, ConfigManager configManager)
-	{
-		String widgets = configManager.getConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(getClueID()));
-		if (widgets != null)
-		{
-			return plugin.gson.fromJson(widgets, new TypeToken<List<Integer>>()
-			{
-			}.getType());
-		}
-		return null;
-	}
-
 	public static boolean isClue(int itemId, boolean isDeveloperMode)
 	{
 		return itemIdClueCache.containsKey(itemId) || (isDeveloperMode && DEV_MODE_IDS.contains(itemId));

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -25,6 +25,8 @@
 package com.cluedetails;
 
 import static com.cluedetails.ClueDetailsConfig.CLUE_ITEMS_CONFIG;
+import static com.cluedetails.ClueDetailsConfig.CLUE_WIDGETS_CONFIG;
+
 import com.cluedetails.filters.ClueTier;
 import com.cluedetails.filters.OrRequirement;
 import com.google.common.collect.ImmutableList;
@@ -1210,6 +1212,18 @@ public class Clues
 		if (items != null)
 		{
 			return plugin.gson.fromJson(items, new TypeToken<List<Integer>>()
+			{
+			}.getType());
+		}
+		return null;
+	}
+
+	public List<Integer> getWidgets(ClueDetailsPlugin plugin, ConfigManager configManager)
+	{
+		String widgets = configManager.getConfiguration(CLUE_WIDGETS_CONFIG, String.valueOf(getClueID()));
+		if (widgets != null)
+		{
+			return plugin.gson.fromJson(widgets, new TypeToken<List<Integer>>()
 			{
 			}.getType());
 		}

--- a/src/main/java/com/cluedetails/WidgetId.java
+++ b/src/main/java/com/cluedetails/WidgetId.java
@@ -1,0 +1,17 @@
+package com.cluedetails;
+
+import lombok.Data;
+import lombok.Getter;
+
+@Getter
+@Data
+public class WidgetId {
+
+    private int componentId;
+    private int childIndex;
+
+    public WidgetId(int componentId, int childIndex) {
+        this.componentId = componentId;
+        this.childIndex = childIndex;
+    }
+}

--- a/src/main/java/com/cluedetails/WidgetId.java
+++ b/src/main/java/com/cluedetails/WidgetId.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2025, cubeee <https://www.github.com/cubeee>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.cluedetails;
 
 import lombok.Data;

--- a/src/main/java/com/cluedetails/WidgetId.java
+++ b/src/main/java/com/cluedetails/WidgetId.java
@@ -5,12 +5,14 @@ import lombok.Getter;
 
 @Getter
 @Data
-public class WidgetId {
+public class WidgetId
+{
 
-    private int componentId;
-    private int childIndex;
+    private final int componentId;
+    private final Integer childIndex;
 
-    public WidgetId(int componentId, int childIndex) {
+    public WidgetId(int componentId, Integer childIndex)
+    {
         this.componentId = componentId;
         this.childIndex = childIndex;
     }

--- a/src/main/java/com/cluedetails/panels/ClueDetailsParentPanel.java
+++ b/src/main/java/com/cluedetails/panels/ClueDetailsParentPanel.java
@@ -463,7 +463,7 @@ public class ClueDetailsParentPanel extends PluginPanel
 			{
 				if (SwingUtilities.isLeftMouseButton(e))
 				{
-					clueDetailsSharingManager.exportClueDetails(true, true, true);
+					clueDetailsSharingManager.exportClueDetails(true, true, true, true);
 				}
 			}
 
@@ -538,21 +538,27 @@ public class ClueDetailsParentPanel extends PluginPanel
 
 		JMenuItem inputItemExportText = new JMenuItem("Export clue text");
 		inputItemExportText.addActionListener(event
-			-> clueDetailsSharingManager.exportClueDetails(true, false, false)
+			-> clueDetailsSharingManager.exportClueDetails(true, false, false, false)
 		);
 		popupMenu.add(inputItemExportText);
 
 		JMenuItem inputItemExportColors = new JMenuItem("Export clue colors");
 		inputItemExportColors.addActionListener(event
-			-> clueDetailsSharingManager.exportClueDetails(false, true, false)
+			-> clueDetailsSharingManager.exportClueDetails(false, true, false, false)
 		);
 		popupMenu.add(inputItemExportColors);
 
 		JMenuItem inputItemExportItems = new JMenuItem("Export clue items");
 		inputItemExportItems.addActionListener(event
-			-> clueDetailsSharingManager.exportClueDetails(false, false, true)
+			-> clueDetailsSharingManager.exportClueDetails(false, false, true, false)
 		);
 		popupMenu.add(inputItemExportItems);
+
+		JMenuItem inputItemExportWidgets = new JMenuItem("Export clue widgets");
+		inputItemExportWidgets.addActionListener(event
+			-> clueDetailsSharingManager.exportClueDetails(false, false, false, true)
+		);
+		popupMenu.add(inputItemExportWidgets);
 
 		return popupMenu;
 	}


### PR DESCRIPTION
Adds a new shift-click submenu to widgets to highlight them when a clue is in the inventory, same as currently supported for items.

New plugin configurations:
* Highlight clue widgets: enable widget highlighting
* Color clue widgets: use clues' colors
* Clue widgets color: the default color to use for highlighting. By default the same yellow as for items, with 50% alpha to not fully mask the widget

![image](https://github.com/user-attachments/assets/3cd6b2d3-4093-4ace-8ba3-0421c0a0b144)
![image](https://github.com/user-attachments/assets/6b6cd55b-3dce-451a-a313-ea83ce16530e)
