### PR TITLE
fix: Cleanup for instantiation of managers and overlays

### DIFF
--- a/src/main/java/com/cluedetails/ClueBankManager.java
+++ b/src/main/java/com/cluedetails/ClueBankManager.java
@@ -24,20 +24,21 @@
  */
 package com.cluedetails;
 
-import com.google.gson.Gson;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
-import net.runelite.client.config.ConfigManager;
 
+@Singleton
 public class ClueBankManager
 {
 	private final Client client;
+	private final ClueDetailsPlugin clueDetailsPlugin;
 	private final ClueBankSaveDataManager clueBankSaveDataManager;
-	private ClueInventoryManager clueInventoryManager;
 
 	Item[] lastBankItems;
 
@@ -45,15 +46,12 @@ public class ClueBankManager
 
 	private final Map<Integer, ClueInstance> cluesGoneFromInventory = new HashMap<>();
 
-	public ClueBankManager(Client client, ConfigManager configManager, Gson gson)
+	@Inject
+	public ClueBankManager(Client client, ClueDetailsPlugin clueDetailsPlugin, ClueBankSaveDataManager clueBankSaveDataManager)
 	{
 		this.client = client;
-		this.clueBankSaveDataManager = new ClueBankSaveDataManager(configManager, gson);
-	}
-
-	public void startUp(ClueInventoryManager clueInventoryManager)
-	{
-		this.clueInventoryManager = clueInventoryManager;
+		this.clueDetailsPlugin = clueDetailsPlugin;
+		this.clueBankSaveDataManager = clueBankSaveDataManager;
 	}
 
 	public void handleBankChange(ItemContainer bankContainer)
@@ -100,11 +98,11 @@ public class ClueBankManager
 		ClueInstance clueFromBank = cluesInBank.get(trackedClueId);
 		if (clueFromBank == null) return;
 
-		ClueInstance clue = clueInventoryManager.getClueByClueItemId(trackedClueId);
+		ClueInstance clue = clueDetailsPlugin.getClueInventoryManager().getClueByClueItemId(trackedClueId);
 		clue.setClueIds(clueFromBank.getClueIds());
 
 		cluesInBank.remove(trackedClueId);
-		clueInventoryManager.updateLastInventoryRefreshTime();
+		clueDetailsPlugin.getClueInventoryManager().updateLastInventoryRefreshTime();
 	}
 
 	public void addToRemovedClues(ClueInstance clueInstance)

--- a/src/main/java/com/cluedetails/ClueBankSaveDataManager.java
+++ b/src/main/java/com/cluedetails/ClueBankSaveDataManager.java
@@ -31,9 +31,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.client.config.ConfigManager;
 
+@Singleton
 public class ClueBankSaveDataManager
 {
 	private final ConfigManager configManager;
@@ -44,6 +47,7 @@ public class ClueBankSaveDataManager
 	private final Gson gson;
 	private final List<ClueInstanceData> clueInstanceData = new ArrayList<>();
 
+	@Inject
 	public ClueBankSaveDataManager(ConfigManager configManager, Gson gson)
 	{
 		this.configManager = configManager;

--- a/src/main/java/com/cluedetails/ClueDetailsInventoryOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsInventoryOverlay.java
@@ -29,7 +29,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 
-import lombok.Setter;
+import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
@@ -38,12 +38,13 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.components.LineComponent;
 
+@Singleton
 public class ClueDetailsInventoryOverlay extends OverlayPanel
 {
 	private final Client client;
 	private final ClueDetailsConfig config;
 	private final ConfigManager configManager;
-	@Setter
+	@Inject
 	private ClueInventoryManager clueInventoryManager;
 
 	private static final Color TITLED_CONTENT_COLOR = new Color(190, 190, 190);

--- a/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsItemsOverlay.java
@@ -34,7 +34,7 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.util.List;
 import javax.inject.Inject;
-import lombok.Setter;
+import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemContainer;
@@ -48,26 +48,28 @@ import net.runelite.client.ui.overlay.WidgetItemOverlay;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.ImageUtil;
 
+@Singleton
 public class ClueDetailsItemsOverlay extends WidgetItemOverlay
 {
 	private final Client client;
 	private final ClueDetailsPlugin clueDetailsPlugin;
 	private final ClueDetailsConfig config;
 	private final ConfigManager configManager;
-	@Setter
-	private ClueInventoryManager clueInventoryManager;
+	private final ClueInventoryManager clueInventoryManager;
 	private final ItemManager itemManager;
 	private final Cache<Long, Image> fillCache;
 	private final Cache<Integer, Clues> clueCache;
 
 	@Inject
-	public ClueDetailsItemsOverlay(Client client, ClueDetailsPlugin clueDetailsPlugin, ClueDetailsConfig config, ConfigManager configManager, ItemManager itemManager)
+	public ClueDetailsItemsOverlay(Client client, ClueDetailsPlugin clueDetailsPlugin, ClueDetailsConfig config,
+	                               ConfigManager configManager, ItemManager itemManager, ClueInventoryManager clueInventoryManager)
 	{
 		this.clueDetailsPlugin = clueDetailsPlugin;
 		this.itemManager = itemManager;
 		this.client = client;
 		this.config = config;
 		this.configManager = configManager;
+		this.clueInventoryManager = clueInventoryManager;
 		showOnBank();
 		showOnEquipment();
 		showOnInventory();

--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 
+import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Menu;
@@ -68,6 +69,7 @@ import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 import net.runelite.client.util.Text;
 
+@Singleton
 public class ClueDetailsOverlay extends OverlayPanel
 {
 	private final Client client;
@@ -78,9 +80,9 @@ public class ClueDetailsOverlay extends OverlayPanel
 	private final ConfigManager configManager;
 
 	private final Notifier notifier;
-	private ClueDetailsPlugin clueDetailsPlugin;
-	private ClueGroundManager clueGroundManager;
-	private ClueInventoryManager clueInventoryManager;
+	private final ClueDetailsPlugin clueDetailsPlugin;
+	private final ClueGroundManager clueGroundManager;
+	private final ClueInventoryManager clueInventoryManager;
 
 	protected Multimap<Tile, Integer> tileHighlights = ArrayListMultimap.create();
 
@@ -88,7 +90,9 @@ public class ClueDetailsOverlay extends OverlayPanel
 	protected static final int SCENE_TO_LOCAL = 128;
 
 	@Inject
-	public ClueDetailsOverlay(Client client, ClueDetailsConfig config, TooltipManager tooltipManager, ModelOutlineRenderer modelOutlineRenderer, ConfigManager configManager, Notifier notifier)
+	public ClueDetailsOverlay(Client client, ClueDetailsPlugin clueDetailsPlugin, ClueDetailsConfig config, ClueGroundManager clueGroundManager,
+	                          ClueInventoryManager clueInventoryManager, TooltipManager tooltipManager, ModelOutlineRenderer modelOutlineRenderer,
+	                          ConfigManager configManager, Notifier notifier)
 	{
 		setPriority(PRIORITY_HIGHEST);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);
@@ -96,6 +100,9 @@ public class ClueDetailsOverlay extends OverlayPanel
 		setPosition(OverlayPosition.TOOLTIP);
 
 		this.client = client;
+		this.clueDetailsPlugin = clueDetailsPlugin;
+		this.clueGroundManager = clueGroundManager;
+		this.clueInventoryManager = clueInventoryManager;
 		this.config = config;
 		this.tooltipManager = tooltipManager;
 		this.modelOutlineRenderer = modelOutlineRenderer;
@@ -107,13 +114,6 @@ public class ClueDetailsOverlay extends OverlayPanel
 		{
 			refreshHighlights();
 		}
-	}
-
-	public void startUp(ClueDetailsPlugin clueDetailsPlugin, ClueGroundManager clueGroundManager, ClueInventoryManager clueInventoryManager)
-	{
-		this.clueDetailsPlugin = clueDetailsPlugin;
-		this.clueGroundManager = clueGroundManager;
-		this.clueInventoryManager = clueInventoryManager;
 	}
 
 	@Override

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -148,17 +148,23 @@ public class ClueDetailsPlugin extends Plugin
 	Gson gson;
 
 	@Getter
+	@Inject
 	private ClueInventoryManager clueInventoryManager;
 
 	@Getter
+	@Inject
 	private ClueWidgetManager clueWidgetManager;
 
 	@Getter
+	@Inject
 	private ClueGroundManager clueGroundManager;
 
+	@Getter
+	@Inject
 	private ClueBankManager clueBankManager;
 
 	@Getter
+	@Inject
 	private CluePreferenceManager cluePreferenceManager;
 
 	@Inject
@@ -199,42 +205,9 @@ public class ClueDetailsPlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
-		overlayManager.add(infoOverlay);
-		eventBus.register(infoOverlay);
+		startUpOverlays();
 
-		overlayManager.add(groundOverlay);
-		eventBus.register(groundOverlay);
-
-		overlayManager.add(tagsOverlay);
-		overlayManager.add(widgetsOverlay);
-
-		overlayManager.add(inventoryOverlay);
-		eventBus.register(inventoryOverlay);
-
-		overlayManager.add(itemsOverlay);
-		eventBus.register(itemsOverlay);
-
-		overlayManager.add(clueThreeStepSaverWidgetOverlay);
-
-		Clues.setConfig(config);
 		Clues.rebuildFilteredCluesCache();
-		ClueInventoryManager.setConfig(config);
-		ClueWidgetManager.setConfig(config);
-
-		cluePreferenceManager = new CluePreferenceManager(this, configManager);
-		clueGroundManager = new ClueGroundManager(client, configManager, this);
-		clueBankManager = new ClueBankManager(client, configManager, gson);
-		clueInventoryManager = new ClueInventoryManager(client, configManager, this, clueGroundManager, clueBankManager, chatboxPanelManager);
-		clueWidgetManager = new ClueWidgetManager(client, configManager, clueInventoryManager, cluePreferenceManager);
-		clueBankManager.startUp(clueInventoryManager);
-		clueThreeStepSaver.startUp(clueInventoryManager);
-
-		infoOverlay.startUp(this, clueGroundManager, clueInventoryManager);
-		groundOverlay.startUp(clueGroundManager, clueThreeStepSaver);
-		inventoryOverlay.setClueInventoryManager(clueInventoryManager);
-		itemsOverlay.setClueInventoryManager(clueInventoryManager);
-		widgetsOverlay.startUp(clueInventoryManager, cluePreferenceManager);
-		clueThreeStepSaverWidgetOverlay.setClueThreeStepSaver(clueThreeStepSaver);
 
 		final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "/icon.png");
 
@@ -254,6 +227,39 @@ public class ClueDetailsPlugin extends Plugin
 
 	@Override
 	protected void shutDown() throws Exception
+	{
+		shutDownOverlays();
+
+		clientToolbar.removeNavigation(navButton);
+
+		clueGroundManager.saveStateToConfig();
+		clueBankManager.saveStateToConfig();
+
+		for (ClueGroundTimer timer : clueGroundTimers)
+		{
+			infoBoxManager.removeInfoBox(timer);
+		}
+	}
+
+	private void startUpOverlays()
+	{
+		overlayManager.add(infoOverlay);
+		eventBus.register(infoOverlay);
+
+		overlayManager.add(groundOverlay);
+		eventBus.register(groundOverlay);
+
+		overlayManager.add(tagsOverlay);
+		overlayManager.add(widgetsOverlay);
+
+		overlayManager.add(inventoryOverlay);
+		eventBus.register(inventoryOverlay);
+
+		overlayManager.add(itemsOverlay);
+		eventBus.register(itemsOverlay);
+	}
+
+	private void shutDownOverlays()
 	{
 		overlayManager.remove(infoOverlay);
 		eventBus.unregister(infoOverlay);
@@ -423,13 +429,8 @@ public class ClueDetailsPlugin extends Plugin
 	@Subscribe
 	public void onMenuOpened(MenuOpened event)
 	{
-		clueThreeStepSaver.onMenuOpened(event);
-	}
-
-	@Subscribe
-	public void onMenuOpened(MenuOpened event)
-	{
 		MenuEntry[] entries = event.getMenuEntries();
+		clueThreeStepSaver.onMenuOpened(event);
 		clueWidgetManager.addHighlightWidgetSubmenus(entries);
 	}
 

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -207,6 +207,8 @@ public class ClueDetailsPlugin extends Plugin
 	{
 		startUpOverlays();
 
+		clueThreeStepSaver.startUp();
+
 		Clues.rebuildFilteredCluesCache();
 
 		final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "/icon.png");
@@ -249,6 +251,7 @@ public class ClueDetailsPlugin extends Plugin
 		overlayManager.add(groundOverlay);
 		eventBus.register(groundOverlay);
 
+		overlayManager.add(clueThreeStepSaverWidgetOverlay);
 		overlayManager.add(tagsOverlay);
 		overlayManager.add(widgetsOverlay);
 

--- a/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsTagsOverlay.java
@@ -81,7 +81,7 @@ public class ClueDetailsTagsOverlay extends WidgetItemOverlay
 
 	private Pair<String, Color> getClueTextFromClueIds(List<Integer> ids)
 	{
-		String clueDetail = null;
+		String clueDetail;
 		Color clueDetailColor = Color.WHITE;
 
 		boolean isFirst = true;

--- a/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsWidgetsOverlay.java
@@ -26,6 +26,7 @@ package com.cluedetails;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.config.ConfigManager;
@@ -39,21 +40,23 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.util.*;
 
+@Singleton
 public class ClueDetailsWidgetsOverlay extends OverlayPanel
 {
 	private final Client client;
 	private final ClueDetailsConfig config;
 	private final ConfigManager configManager;
 
-	private ClueInventoryManager clueInventoryManager;
-	private CluePreferenceManager cluePreferenceManager;
+	private final ClueInventoryManager clueInventoryManager;
+	private final CluePreferenceManager cluePreferenceManager;
 
 	private final Cache<WidgetId, Color> clueColorCache;
 
 	private long lastUpdate = Integer.MAX_VALUE;
 
 	@Inject
-	public ClueDetailsWidgetsOverlay(Client client, ClueDetailsConfig config, ConfigManager configManager)
+	public ClueDetailsWidgetsOverlay(Client client, ClueDetailsConfig config, ConfigManager configManager,
+	                                 ClueInventoryManager clueInventoryManager, CluePreferenceManager cluePreferenceManager)
 	{
 		setPriority(PRIORITY_HIGHEST);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);
@@ -63,17 +66,13 @@ public class ClueDetailsWidgetsOverlay extends OverlayPanel
 		this.client = client;
 		this.config = config;
 		this.configManager = configManager;
+		this.clueInventoryManager = clueInventoryManager;
+		this.cluePreferenceManager = cluePreferenceManager;
 
 		this.clueColorCache = CacheBuilder.newBuilder()
 			.concurrencyLevel(1)
 			.maximumSize(100)
 			.build();
-	}
-
-	public void startUp(ClueInventoryManager clueInventoryManager, CluePreferenceManager cluePreferenceManager)
-	{
-		this.clueInventoryManager = clueInventoryManager;
-		this.cluePreferenceManager = cluePreferenceManager;
 	}
 
 	public void cacheInventoryCluesWidgetColors()

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -26,6 +26,8 @@ package com.cluedetails;
 
 import com.cluedetails.filters.ClueTier;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import lombok.Getter;
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
@@ -33,8 +35,8 @@ import net.runelite.api.events.ItemDespawned;
 import net.runelite.api.events.ItemSpawned;
 
 import java.util.*;
-import net.runelite.client.config.ConfigManager;
 
+@Singleton
 public class ClueGroundManager
 {
 	private final Client client;
@@ -48,16 +50,17 @@ public class ClueGroundManager
 	private final int MAX_DESPAWN_TIMER = 6100;
 	private Zone lastZone;
 	private Zone currentZone;
-	private WorldPointToClueInstances trackedClues;
+	private final WorldPointToClueInstances trackedClues;
 	private boolean loggedInStateOccuredThisTick;
-	private Set<WorldPoint> tileClearedThisTick = new HashSet<>();
-	private Set<Tile> easyToEliteClueSpawnedThisTick = new HashSet<>();
+	private final Set<WorldPoint> tileClearedThisTick = new HashSet<>();
+	private final Set<Tile> easyToEliteClueSpawnedThisTick = new HashSet<>();
 
-	public ClueGroundManager(Client client, ConfigManager configManager, ClueDetailsPlugin clueDetailsPlugin)
+	@Inject
+	public ClueGroundManager(Client client, ClueGroundSaveDataManager clueGroundSaveDataManager, ClueDetailsPlugin clueDetailsPlugin)
 	{
 		this.client = client;
 		this.clueDetailsPlugin = clueDetailsPlugin;
-		this.clueGroundSaveDataManager = new ClueGroundSaveDataManager(configManager, clueDetailsPlugin.gson);
+		this.clueGroundSaveDataManager = clueGroundSaveDataManager;
 		clueGroundSaveDataManager.loadStateFromConfig(client);
 
 		trackedClues = new WorldPointToClueInstances(client, clueDetailsPlugin);
@@ -139,7 +142,7 @@ public class ClueGroundManager
 			Optional<ClueInstance> optionalClue = cluesAtLocation.stream()
 				.filter((clue) -> clue.getTileItem() == item)
 				.findFirst();
-			optionalClue.ifPresent((clueInstance -> trackedClues.removeClue(clueInstance)));
+			optionalClue.ifPresent((trackedClues::removeClue));
 			return;
 		}
 
@@ -169,7 +172,7 @@ public class ClueGroundManager
 			.filter((clue) -> clue.getTileItem() == item)
 			.findFirst();
 		optionalClue.ifPresent(despawnedClueQueueForInventoryCheck::add);
-		optionalClue.ifPresent((clueInstance -> trackedClues.removeClue(clueInstance)));
+		optionalClue.ifPresent((trackedClues::removeClue));
 	}
 
 	public Set<WorldPoint> getTrackedWorldPoints()

--- a/src/main/java/com/cluedetails/ClueGroundOverlay.java
+++ b/src/main/java/com/cluedetails/ClueGroundOverlay.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Player;
@@ -51,6 +52,7 @@ import static com.cluedetails.ClueDetailsConfig.SavedThreeStepperEnum.BOTH;
 import static com.cluedetails.ClueDetailsConfig.SavedThreeStepperEnum.GROUND;
 
 // Heavily lifted from net.runelite.client.plugins.grounditems.GroundItemsOverlay
+@Singleton
 public class ClueGroundOverlay extends Overlay
 {
 	private static final int MAX_DISTANCE = 2500;
@@ -68,11 +70,12 @@ public class ClueGroundOverlay extends Overlay
 	private final Map<WorldPoint, Integer> offsetMap = new HashMap<>();
 	private final ConfigManager configManager;
 	private final ClueDetailsPlugin plugin;
-	private ClueGroundManager clueGroundManager;
-	private ClueThreeStepSaver clueThreeStepSaver;
+	private final ClueGroundManager clueGroundManager;
+	private final ClueThreeStepSaver clueThreeStepSaver;
 
 	@Inject
-	private ClueGroundOverlay(ClueDetailsPlugin plugin, Client client, ClueDetailsConfig config, ConfigManager configManager, ClueThreeStepSaver clueThreeStepSaver)
+	private ClueGroundOverlay(ClueDetailsPlugin plugin, Client client, ClueDetailsConfig config, ConfigManager configManager,
+	                          ClueThreeStepSaver clueThreeStepSaver, ClueGroundManager clueGroundManager)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.UNDER_WIDGETS);
@@ -81,12 +84,7 @@ public class ClueGroundOverlay extends Overlay
 		this.config = config;
 		this.configManager = configManager;
 		this.clueThreeStepSaver = clueThreeStepSaver;
-	}
-
-	public void startUp(ClueGroundManager clueGroundManager, ClueThreeStepSaver clueThreeStepSaver)
-	{
 		this.clueGroundManager = clueGroundManager;
-		this.clueThreeStepSaver = clueThreeStepSaver;
 	}
 
 	@Override

--- a/src/main/java/com/cluedetails/ClueGroundSaveDataManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundSaveDataManager.java
@@ -31,10 +31,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.config.ConfigManager;
 
+@Singleton
 public class ClueGroundSaveDataManager
 {
 	private final ConfigManager configManager;
@@ -43,6 +46,7 @@ public class ClueGroundSaveDataManager
 	private static final String GROUND_CLUES_KEY = "ground-clues";
 	private final List<ClueInstanceData> clueInstanceData = new ArrayList<>();
 
+	@Inject
 	public ClueGroundSaveDataManager(ConfigManager configManager, Gson gson)
 	{
 		this.configManager = configManager;

--- a/src/main/java/com/cluedetails/ClueInventoryManager.java
+++ b/src/main/java/com/cluedetails/ClueInventoryManager.java
@@ -27,10 +27,10 @@ package com.cluedetails;
 import com.cluedetails.panels.ClueDetailsParentPanel;
 
 import java.util.*;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
@@ -57,26 +57,23 @@ public class ClueInventoryManager
 	private final ConfigManager configManager;
 	private final ClueDetailsPlugin clueDetailsPlugin;
 	private final ClueGroundManager clueGroundManager;
-	private final ClueBankManager clueBankManager;
 	private final ChatboxPanelManager chatboxPanelManager;
 	private final Map<Integer, ClueInstance> cluesInInventory = new HashMap<>();
 	private final Map<Integer, ClueInstance> previousCluesInInventory = new HashMap<>();
 
 	@Getter
 	private long lastInventoryUpdate = 0;
+	private final ClueDetailsConfig config;
 
-	// To be initialized to avoid passing around
-	@Setter
-	public static ClueDetailsConfig config;
-
-	public ClueInventoryManager(Client client, ConfigManager configManager, ClueDetailsPlugin clueDetailsPlugin, ClueGroundManager clueGroundManager,
-								ClueBankManager clueBankManager, ChatboxPanelManager chatboxPanelManager)
+	@Inject
+	public ClueInventoryManager(Client client, ConfigManager configManager, ClueDetailsPlugin clueDetailsPlugin, ClueDetailsConfig config, ClueGroundManager clueGroundManager,
+								ChatboxPanelManager chatboxPanelManager)
 	{
 		this.client = client;
+		this.config = config;
 		this.configManager = configManager;
 		this.clueDetailsPlugin = clueDetailsPlugin;
 		this.clueGroundManager = clueGroundManager;
-		this.clueBankManager = clueBankManager;
 		this.chatboxPanelManager = chatboxPanelManager;
 	}
 
@@ -114,7 +111,7 @@ public class ClueInventoryManager
 				ClueInstance removedClue = previousCluesInInventory.get(itemId);
 				if (removedClue != null)
 				{
-					clueBankManager.addToRemovedClues(removedClue);
+					clueDetailsPlugin.getClueBankManager().addToRemovedClues(removedClue);
 				}
 			}
 		}

--- a/src/main/java/com/cluedetails/CluePreferenceManager.java
+++ b/src/main/java/com/cluedetails/CluePreferenceManager.java
@@ -31,13 +31,17 @@ import com.google.gson.reflect.TypeToken;
 import java.util.List;
 import java.util.stream.*;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import net.runelite.client.config.ConfigManager;
 
+@Singleton
 public class CluePreferenceManager
 {
 	private final ClueDetailsPlugin clueDetailsPlugin;
 	private final ConfigManager configManager;
 
+	@Inject
 	public CluePreferenceManager(ClueDetailsPlugin clueDetailsPlugin, ConfigManager configManager)
 	{
 		this.clueDetailsPlugin = clueDetailsPlugin;

--- a/src/main/java/com/cluedetails/ClueThreeStepSaver.java
+++ b/src/main/java/com/cluedetails/ClueThreeStepSaver.java
@@ -30,6 +30,7 @@ public class ClueThreeStepSaver
 	@Inject
 	private Gson gson;
 
+	@Inject
 	private ClueInventoryManager cim;
 
 	private ClueInstance activeMaster;

--- a/src/main/java/com/cluedetails/ClueThreeStepSaver.java
+++ b/src/main/java/com/cluedetails/ClueThreeStepSaver.java
@@ -1,6 +1,7 @@
 package com.cluedetails;
 
 import com.google.gson.Gson;
+import javax.inject.Singleton;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
@@ -15,9 +16,9 @@ import net.runelite.client.config.ConfigManager;
 import javax.inject.Inject;
 
 @Slf4j
+@Singleton
 public class ClueThreeStepSaver
 {
-
 	@Inject
 	private Client client;
 
@@ -135,9 +136,8 @@ public class ClueThreeStepSaver
 		savedThreeStepper = gson.fromJson(threeStepMasterJson, ClueInstance.class);
 	}
 
-	public void startUp(ClueInventoryManager clueInventoryManager)
+	public void startUp()
 	{
-		this.cim = clueInventoryManager;
 		updateThreeStepper();
 		scanInventory();
 	}

--- a/src/main/java/com/cluedetails/ClueThreeStepSaverWidgetOverlay.java
+++ b/src/main/java/com/cluedetails/ClueThreeStepSaverWidgetOverlay.java
@@ -1,6 +1,6 @@
 package com.cluedetails;
 
-import lombok.Setter;
+import javax.inject.Singleton;
 import net.runelite.api.ItemID;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
@@ -10,13 +10,13 @@ import java.awt.Graphics2D;
 import static com.cluedetails.ClueDetailsConfig.SavedThreeStepperEnum.BOTH;
 import static com.cluedetails.ClueDetailsConfig.SavedThreeStepperEnum.INVENTORY;
 
+@Singleton
 public class ClueThreeStepSaverWidgetOverlay extends WidgetItemOverlay
 {
 	private final ClueDetailsPlugin clueDetailsPlugin;
 	private final ClueDetailsConfig config;
 
-	@Setter
-	private ClueThreeStepSaver clueThreeStepSaver;
+	private final ClueThreeStepSaver clueThreeStepSaver;
 
 	@Inject
 	private ClueThreeStepSaverWidgetOverlay(ClueDetailsPlugin clueDetailsPlugin, ClueThreeStepSaver clueThreeStepSaver, ClueDetailsConfig config)

--- a/src/main/java/com/cluedetails/ClueWidgetManager.java
+++ b/src/main/java/com/cluedetails/ClueWidgetManager.java
@@ -24,7 +24,7 @@
  */
 package com.cluedetails;
 
-import lombok.Setter;
+import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.KeyCode;
 import net.runelite.api.Menu;
@@ -44,6 +44,7 @@ public class ClueWidgetManager
     private final ClueInventoryManager clueInventoryManager;
     private final CluePreferenceManager cluePreferenceManager;
 
+	@Inject
     public ClueWidgetManager(Client client, ConfigManager configManager, ClueInventoryManager clueInventoryManager, CluePreferenceManager cluePreferenceManager)
     {
         this.client = client;
@@ -51,10 +52,6 @@ public class ClueWidgetManager
         this.clueInventoryManager = clueInventoryManager;
         this.cluePreferenceManager = cluePreferenceManager;
     }
-
-    // To be initialized to avoid passing around
-    @Setter
-    public static ClueDetailsConfig config;
 
     public void addHighlightWidgetSubmenus(MenuEntry[] entries)
     {

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.ItemID;
@@ -1032,6 +1033,7 @@ public class Clues
 
 	// To be initialized to avoid passing around
 	@Setter
+	@Inject
 	public static ClueDetailsConfig config;
 
 	Clues(String clueDetail, int itemID, ClueTier clueTier, String clueText, List<WorldPoint> wps)


### PR DESCRIPTION
It was getting quite messy with all the managers and overlays we were using, and we had some Singletons being potentially instantiated multiple times, and partial injections being used.