### PR TITLE
fix: Ignore spawn/despawn events caused by plane change

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -202,6 +202,9 @@ public class ClueDetailsPlugin extends Plugin
 	@Getter
 	public static int currentTick;
 
+	@Getter
+	public static int currentPlane;
+
 	@Override
 	protected void startUp() throws Exception
 	{
@@ -373,6 +376,8 @@ public class ClueDetailsPlugin extends Plugin
 	{
 		clueGroundManager.onGameTick();
 		clueInventoryManager.onGameTick();
+
+		currentPlane = client.getTopLevelWorldView().getPlane();
 
 		renderGroundClueTimers(); // TODO: Call more efficiently
 		infoBoxManager.cull(); // Explict call to clean up timers faster

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -124,6 +124,9 @@ public class ClueGroundManager
 		if (!Clues.isClue(item.getId(), clueDetailsPlugin.isDeveloperMode())) return;
 		WorldPoint location = event.getTile().getWorldLocation();
 
+		// Only process events where the actual item has just despawned
+		if (ClueDetailsPlugin.getCurrentPlane() != location.getPlane()) return;
+
 		if (!Clues.isBeginnerOrMasterClue(item.getId(), clueDetailsPlugin.isDeveloperMode()))
 		{
 			ClueInstance clueInstance = new ClueInstance(List.of(), item.getId(), location, item, client.getTickCount());


### PR DESCRIPTION
the server only sends a despawn event when the actual object does
despawn or when you change to that objects level and the server
sends it to sync you with that planes objects.  By setting the current
player plane on gametick and checking that against the despawned objects
plane, and only processing events where they match we can gurantee
that the actual object has just despawned instead of the server sending
the event just to resync the player with the current status of the
location they just entered