### PR TITLE
fix: Clear ground clues on restart

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -208,6 +208,7 @@ public class ClueDetailsPlugin extends Plugin
 		startUpOverlays();
 
 		clueThreeStepSaver.startUp();
+		clueGroundManager.startUp();
 
 		Clues.rebuildFilteredCluesCache();
 

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -208,7 +208,7 @@ public class ClueDetailsPlugin extends Plugin
 		startUpOverlays();
 
 		clueThreeStepSaver.startUp();
-		clueGroundManager.loadStateFromConfig();
+		clueGroundManager.startUp();
 
 		Clues.rebuildFilteredCluesCache();
 
@@ -232,6 +232,8 @@ public class ClueDetailsPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		shutDownOverlays();
+
+		clueGroundManager.shutDown();
 
 		clientToolbar.removeNavigation(navButton);
 

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -208,7 +208,7 @@ public class ClueDetailsPlugin extends Plugin
 		startUpOverlays();
 
 		clueThreeStepSaver.startUp();
-		clueGroundManager.startUp();
+		clueGroundManager.loadStateFromConfig();
 
 		Clues.rebuildFilteredCluesCache();
 

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -65,12 +65,6 @@ public class ClueGroundManager
 		trackedClues = new WorldPointToClueInstances(client, clueDetailsPlugin);
 	}
 
-	public void startUp()
-	{
-		clueGroundSaveDataManager.loadStateFromConfig(client);
-		trackedClues.clearAllClues();
-	}
-
 	public SortedSet<ClueInstance> getAllGroundCluesOnWp(WorldPoint worldPoint)
 	{
 		return trackedClues.getAllCluesAtWorldPoint(worldPoint);

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -61,9 +61,14 @@ public class ClueGroundManager
 		this.client = client;
 		this.clueDetailsPlugin = clueDetailsPlugin;
 		this.clueGroundSaveDataManager = clueGroundSaveDataManager;
-		clueGroundSaveDataManager.loadStateFromConfig(client);
 
 		trackedClues = new WorldPointToClueInstances(client, clueDetailsPlugin);
+	}
+
+	public void startUp()
+	{
+		clueGroundSaveDataManager.loadStateFromConfig(client);
+		trackedClues.clearAllClues();
 	}
 
 	public SortedSet<ClueInstance> getAllGroundCluesOnWp(WorldPoint worldPoint)

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.Getter;
+import lombok.Setter;
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ItemDespawned;
@@ -51,6 +52,8 @@ public class ClueGroundManager
 	private Zone lastZone;
 	private Zone currentZone;
 	private final WorldPointToClueInstances trackedClues;
+
+	@Setter
 	private boolean loggedInStateOccuredThisTick;
 	private final Set<WorldPoint> tileClearedThisTick = new HashSet<>();
 	private final Set<Tile> easyToEliteClueSpawnedThisTick = new HashSet<>();
@@ -63,6 +66,18 @@ public class ClueGroundManager
 		this.clueGroundSaveDataManager = clueGroundSaveDataManager;
 
 		trackedClues = new WorldPointToClueInstances(client, clueDetailsPlugin);
+	}
+
+	public void startUp()
+	{
+		loadStateFromConfig();
+		setLoggedInStateOccuredThisTick(true);
+	}
+
+	public void shutDown()
+	{
+		// Need to clear incase the player toggles the plugin on/off on the same tick
+		tileClearedThisTick.clear();
 	}
 
 	public SortedSet<ClueInstance> getAllGroundCluesOnWp(WorldPoint worldPoint)

--- a/src/main/java/com/cluedetails/WorldPointToClueInstances.java
+++ b/src/main/java/com/cluedetails/WorldPointToClueInstances.java
@@ -82,7 +82,7 @@ public class WorldPointToClueInstances
 			}
 		}
 
-		if (cluesByWorldPoint.get(wp).isEmpty())
+		if (cluesByWorldPoint.get(wp) != null && cluesByWorldPoint.get(wp).isEmpty())
 		{
 			cluesByWorldPoint.remove(wp);
 		}


### PR DESCRIPTION
Addresses ground clue overlay duplication seen when plugin toggled