### PR TITLE
fix: Remember beginner/master clues when traversing planes

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -202,6 +202,9 @@ public class ClueDetailsPlugin extends Plugin
 	@Getter
 	public static int currentTick;
 
+	@Getter
+	public static int currentPlane;
+
 	@Override
 	protected void startUp() throws Exception
 	{
@@ -373,6 +376,8 @@ public class ClueDetailsPlugin extends Plugin
 	{
 		clueGroundManager.onGameTick();
 		clueInventoryManager.onGameTick();
+
+		currentPlane = client.getTopLevelWorldView().getPlane();
 
 		renderGroundClueTimers(); // TODO: Call more efficiently
 		infoBoxManager.cull(); // Explict call to clean up timers faster

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -124,6 +124,14 @@ public class ClueGroundManager
 		if (!Clues.isClue(item.getId(), clueDetailsPlugin.isDeveloperMode())) return;
 		WorldPoint location = event.getTile().getWorldLocation();
 
+		// Only process events where the actual item has just despawned
+		// This helps to retain identified clues
+		if (event.getItem().getId() == ItemID.CLUE_SCROLL_BEGINNER
+			|| event.getItem().getId() == ItemID.CLUE_SCROLL_MASTER)
+		{
+			if (ClueDetailsPlugin.getCurrentPlane() != location.getPlane()) return;
+		}
+
 		if (!Clues.isBeginnerOrMasterClue(item.getId(), clueDetailsPlugin.isDeveloperMode()))
 		{
 			ClueInstance clueInstance = new ClueInstance(List.of(), item.getId(), location, item, client.getTickCount());


### PR DESCRIPTION
Previous behavior is that all tracked beginner/master clues are forgotten when traversing a plane in render distance of the clues.

Applying this change to all tiers seemed to result in duplication of tracked easy->elite clues.

This change only seems to consistently remember the beginner/master clues once the tile has been fully juggled. If it has not been, all beginner/master clues of that tier are reset to unknown state.