### PR TITLE
feat: Use tier name for unidentified ground clues overlay

### DIFF
--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -140,10 +140,11 @@ public class ClueInstance
 	{
 		StringBuilder itemStringBuilder = new StringBuilder();
 		List<Integer> clueIds = this.getClueIds();
+		String clueText;
 
 		if (clueIds.isEmpty())
 		{
-			itemStringBuilder.append(this.getItemName(plugin));
+			clueText = WordUtils.capitalizeFully(this.getTier().toString().replace("_", " "));
 		}
 		else
 		{
@@ -155,7 +156,6 @@ public class ClueInstance
 				return null;
 			}
 
-			String clueText;
 			if (config.changeGroundClueText() && !config.collapseGroundCluesByTier())
 			{
 				if (clueIds.size() > 1)
@@ -171,9 +171,8 @@ public class ClueInstance
 			{
 				clueText = WordUtils.capitalizeFully(clueDetails.getClueTier().toString().replace("_", " "));
 			}
-
-			itemStringBuilder.append(clueText);
 		}
+		itemStringBuilder.append(clueText);
 
 		if ((config.collapseGroundClues() || config.collapseGroundCluesByTier()) && quantity > 1)
 		{
@@ -260,11 +259,6 @@ public class ClueInstance
 		}
 		if (returnText.length() == 0) return null;
 		return returnText.toString();
-	}
-
-	public String getItemName(ClueDetailsPlugin plugin)
-	{
-		return plugin.getItemManager().getItemComposition(itemId).getName();
 	}
 
 	public boolean isEnabled(ClueDetailsConfig config)


### PR DESCRIPTION
Using tier  name for unidentified beginner and master clues provides a more cohesive and clean overlay when transitioning between settings

Before: Becomes unclear that the collapsed Beginner is identified
![kB3F3Tp](https://github.com/user-attachments/assets/06469c4c-68e4-4cb7-9fcc-cbbdca0bb816)

After:
![VzxT5Zm](https://github.com/user-attachments/assets/63ed8276-5a0f-4029-98d5-800a2ef77984)