### PR TITLE
fix: three-step cryptic submenu order

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsOverlay.java
@@ -26,6 +26,7 @@
 package com.cluedetails;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -292,7 +293,7 @@ public class ClueDetailsOverlay extends OverlayPanel
 			{
 				Menu submenu = menuEntry.createSubMenu();
 
-				for (String text : newTexts)
+				for (String text : ImmutableList.copyOf(newTexts).reverse())
 				{
 					submenu.createMenuEntry(-1)
 						.setOption(text)


### PR DESCRIPTION
Submenu order was showing reverse order

Before
![HgiS4x1](https://github.com/user-attachments/assets/9e10b071-9a14-4496-b56e-85f2f52ce99d)

After
![m7LuxGk](https://github.com/user-attachments/assets/905ff314-fedb-482f-b6c7-9b90e9bfa19a)
