### PR TITLE
feat: Reverse ground clues overlay

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -616,11 +616,23 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "reverseGroundCluesOverlay",
+		name = "Reverse ground clues overlay",
+		description = "Reverses the ground clues overlay to render under item(s) rather than on top",
+		section = groundCluesSection,
+		position = 5
+	)
+	default boolean reverseGroundCluesOverlay()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "colorGroundClues",
 		name = "Color ground clues",
 		description = "Toggle whether to apply clue details color to ground clue text",
 		section = groundCluesSection,
-		position = 5
+		position = 6
 	)
 	default boolean colorGroundClues()
 	{
@@ -633,7 +645,7 @@ public interface ClueDetailsConfig extends Config
 		description = "Toggle whether to show timer infoboxes for ground clues",
 		warning = "Experimental feature! Timers may not behave as expected. Please use caution",
 		section = groundCluesSection,
-		position = 6
+		position = 7
 	)
 	default boolean showGroundClueTimers()
 	{
@@ -645,7 +657,7 @@ public interface ClueDetailsConfig extends Config
 		name = "Timer notifications",
 		description = "Seconds remaining until despawn per tile to send notification. Set to 0 to disable the notification.",
 		section = groundCluesSection,
-		position = 7
+		position = 8
 	)
 	default int groundClueTimersNotificationTime()
 	{
@@ -658,7 +670,7 @@ public interface ClueDetailsConfig extends Config
 		description = "Seconds after initial notificiaton to periodically renotify. Set to 0 to disable the notification." +
 			"<br> This also acts as a cooldown between notifications for clues in the same tile",
 		section = groundCluesSection,
-		position = 8
+		position = 9
 	)
 	default int groundClueTimersRenotificationTime()
 	{

--- a/src/main/java/com/cluedetails/ClueGroundOverlay.java
+++ b/src/main/java/com/cluedetails/ClueGroundOverlay.java
@@ -206,18 +206,20 @@ public class ClueGroundOverlay extends Overlay
 	{
 		final String itemString = item.getGroundText(plugin, config, configManager, quantity);
 
+		final int zDirection = config.reverseGroundCluesOverlay() ? -1 : 1;
+
 		final Point textPoint = Perspective.getCanvasTextLocation(client,
 			graphics,
 			groundPoint,
 			itemString,
-			CLUE_ITEM_HEIGHT + OFFSET_Z);
+			CLUE_ITEM_HEIGHT + (OFFSET_Z * zDirection));
 
 		if (textPoint == null)
 		{
 			return;
 		}
 
-		final int offset = offsetMap.compute(item.getLocation(), (k, v) -> v != null ? v + 1 : 0);
+		final int offset = offsetMap.compute(item.getLocation(), (k, v) -> v != null ? v + zDirection : 0);
 
 		final int textX = textPoint.getX();
 		final int textY = textPoint.getY() - (STRING_GAP * offset);


### PR DESCRIPTION
Ability to reverse the overlay to de-conflict with ground items overlay when users do not want to hide clues or want to handle mixed item piles

![auoivBP](https://github.com/user-attachments/assets/5f45b638-512a-4059-aded-a352ab2197ea)