### PR TITLE
fix: Avoid duping clues when entering clue area

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -345,14 +345,8 @@ public class ClueDetailsPlugin extends Plugin
 			profileChanged = true;
 		}
 
-		if (event.getGameState() == GameState.LOADING)
-		{
-			clueGroundManager.setLoggedInOccuredThisTick(true);
-		}
-
 		if (event.getGameState() == GameState.LOGGED_IN)
 		{
-			clueGroundManager.setLoggedInOccuredThisTick(true);
 			if (profileChanged)
 			{
 				profileChanged = false;

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -191,8 +191,6 @@ public class ClueGroundManager
 
 	public void onGameTick()
 	{
-		resetEasyToEliteThisTick.forEach(this::createEasyToEliteForTile);
-		resetEasyToEliteThisTick.clear();
 		currentZone = new Zone(client.getLocalPlayer().getWorldLocation());
 		trackedClues.clearEmptyTiles(currentZone);
 
@@ -202,6 +200,8 @@ public class ClueGroundManager
 		}
 		itemHasSpawnedOnTileThisTick.clear();
 		trackedClues.removeDespawnedClues();
+		resetEasyToEliteThisTick.forEach(this::createEasyToEliteForTile);
+		resetEasyToEliteThisTick.clear();
 
 		lastZone = currentZone;
 	}

--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -93,11 +93,12 @@ public class ClueGroundManager
 		if (!Clues.isClue(item.getId(), clueDetailsPlugin.isDeveloperMode())) return;
 
 		// If easy-elite task, we just override
-		// TODO: Maybe also means torn clues and such?
 		if (!Clues.isBeginnerOrMasterClue(item.getId(), clueDetailsPlugin.isDeveloperMode()))
 		{
+			// If not max despawn time, must be an old clue. Wipe tile as we must be loading in tile.
+			boolean isMaxDespawnTime = item.getDespawnTime() == MAX_DESPAWN_TIMER;
 			// We don't get items removed when a loading->logged in state occurs. This clears the tile
-			if (loggedInStateOccuredThisTick && !tileClearedThisTick.contains(tile.getWorldLocation()))
+			if ((!isMaxDespawnTime || loggedInStateOccuredThisTick) && !tileClearedThisTick.contains(tile.getWorldLocation()))
 			{
 				tileClearedThisTick.add(tile.getWorldLocation());
 				clearEasyToEliteCluesAtWorldPoint(tile.getWorldLocation());


### PR DESCRIPTION
This allows for easy-elite clues to be renewed should a spawning clue be an old clue (aka we must be loading the tile without a load screen).