### PR TITLE
Allow highlighting widgets with "Continue" option and no actions

### DIFF
--- a/src/main/java/com/cluedetails/ClueWidgetManager.java
+++ b/src/main/java/com/cluedetails/ClueWidgetManager.java
@@ -70,7 +70,7 @@ public class ClueWidgetManager
             MenuEntry entry = entries[idx];
 
             Widget widget = entry.getWidget();
-            if (widget == null || widget.getActions() == null)
+            if (widget == null || (widget.getActions() == null && entry.getType() != MenuAction.WIDGET_CONTINUE))
             {
                 return;
             }


### PR DESCRIPTION
Specifically targets Portal Nexus teleports when not using "Better Teleport Menu" plugin which adds "Set hotkey" actions. By default portal nexus teleport menu entries have no actions so they were being skipped.

By enabling "Continue" this will also enable highlighting more options such as dialogue options

![image](https://github.com/user-attachments/assets/1acfb4e8-c2c4-4a8d-87cf-2a6bcf142311)
