### PR TITLE
fix: Clue Instance despawn time tracking

### DIFF
--- a/src/main/java/com/cluedetails/ClueBankManager.java
+++ b/src/main/java/com/cluedetails/ClueBankManager.java
@@ -29,14 +29,12 @@ import com.google.inject.Singleton;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 
 @Singleton
 public class ClueBankManager
 {
-	private final Client client;
 	private final ClueDetailsPlugin clueDetailsPlugin;
 	private final ClueBankSaveDataManager clueBankSaveDataManager;
 
@@ -47,9 +45,8 @@ public class ClueBankManager
 	private final Map<Integer, ClueInstance> cluesGoneFromInventory = new HashMap<>();
 
 	@Inject
-	public ClueBankManager(Client client, ClueDetailsPlugin clueDetailsPlugin, ClueBankSaveDataManager clueBankSaveDataManager)
+	public ClueBankManager(ClueDetailsPlugin clueDetailsPlugin, ClueBankSaveDataManager clueBankSaveDataManager)
 	{
-		this.client = client;
 		this.clueDetailsPlugin = clueDetailsPlugin;
 		this.clueBankSaveDataManager = clueBankSaveDataManager;
 	}
@@ -112,13 +109,13 @@ public class ClueBankManager
 
 	public void saveStateToConfig()
 	{
-		clueBankSaveDataManager.saveStateToConfig(client, cluesInBank);
+		clueBankSaveDataManager.saveStateToConfig(cluesInBank);
 	}
 
 	public void loadStateFromConfig()
 	{
 		cluesInBank.clear();
 		cluesGoneFromInventory.clear();
-		cluesInBank.putAll(clueBankSaveDataManager.loadStateFromConfig(client));
+		cluesInBank.putAll(clueBankSaveDataManager.loadStateFromConfig());
 	}
 }

--- a/src/main/java/com/cluedetails/ClueBankSaveDataManager.java
+++ b/src/main/java/com/cluedetails/ClueBankSaveDataManager.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import net.runelite.api.Client;
 import net.runelite.client.config.ConfigManager;
 
 @Singleton
@@ -54,29 +53,27 @@ public class ClueBankSaveDataManager
 		this.gson = gson;
 	}
 
-	public void saveStateToConfig(Client client, Map<Integer, ClueInstance> bankClues)
+	public void saveStateToConfig(Map<Integer, ClueInstance> bankClues)
 	{
 		// Serialize groundClues save to config
-		updateData(client, bankClues);
+		updateData(bankClues);
 		String bankCluesData = gson.toJson(clueInstanceData);
 		configManager.setConfiguration(CONFIG_GROUP, BANK_CLUES_KEY, bankCluesData);
 	}
 
-	private void updateData(Client client, Map<Integer, ClueInstance> bankClues)
+	private void updateData(Map<Integer, ClueInstance> bankClues)
 	{
-		int currentTick = client.getTickCount();
-
 		List<ClueInstanceData> newData = new ArrayList<>();
 		for (Map.Entry<Integer, ClueInstance> entry : bankClues.entrySet())
 		{
 			ClueInstance data = entry.getValue();
-			newData.add(new ClueInstanceData(data, currentTick));
+			newData.add(new ClueInstanceData(data));
 		}
 		clueInstanceData.clear();
 		clueInstanceData.addAll(newData);
 	}
 
-	public Map<Integer, ClueInstance> loadStateFromConfig(Client client)
+	public Map<Integer, ClueInstance> loadStateFromConfig()
 	{
 		String groundCluesJson = configManager.getConfiguration(CONFIG_GROUP, BANK_CLUES_KEY);
 		clueInstanceData.clear();
@@ -105,7 +102,7 @@ public class ClueBankSaveDataManager
 			} catch (Exception err)
 			{
 				bankClues.clear();
-				saveStateToConfig(client, bankClues);
+				saveStateToConfig(bankClues);
 			}
 		}
 

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -532,7 +532,7 @@ public class ClueDetailsPlugin extends Plugin
 		// Populate timers
 		for (WorldPoint worldPoint : worldPoints)
 		{
-			TreeMap<ClueInstance, Integer> clueInstancesWithQuantityAtWp = clueGroundManager.getClueInstancesWithQuantityAtWp(config, worldPoint, client.getTickCount());
+			TreeMap<ClueInstance, Integer> clueInstancesWithQuantityAtWp = clueGroundManager.getClueInstancesWithQuantityAtWp(config, worldPoint);
 
 			if (clueInstancesWithQuantityAtWp != null && clueInstancesWithQuantityAtWp.firstEntry() != null)
 			{
@@ -547,7 +547,7 @@ public class ClueDetailsPlugin extends Plugin
 					}
 				}
 
-				int despawnTick = oldestEnabledClueInstance.getDespawnTick(client.getTickCount());
+				int despawnTick = oldestEnabledClueInstance.getDespawnTick();
 
 				boolean createNewTimer = true;
 

--- a/src/main/java/com/cluedetails/ClueGroundOverlay.java
+++ b/src/main/java/com/cluedetails/ClueGroundOverlay.java
@@ -124,7 +124,7 @@ public class ClueGroundOverlay extends Overlay
 			}
 
 			// Get list of ClueInstances at wp with optionally collapsed quantities
-			Map<ClueInstance, Integer> clueInstancesWithQuantityAtWp = clueGroundManager.getClueInstancesWithQuantityAtWp(config, wp, client.getTickCount());
+			Map<ClueInstance, Integer> clueInstancesWithQuantityAtWp = clueGroundManager.getClueInstancesWithQuantityAtWp(config, wp);
 
 			if (clueInstancesWithQuantityAtWp == null)
 			{
@@ -174,7 +174,7 @@ public class ClueGroundOverlay extends Overlay
 
 	private int getSecondsLeft(ClueInstance item)
 	{
-		int ticksLeft = item.getDespawnTick(client.getTickCount()) - client.getTickCount();
+		int ticksLeft = item.getDespawnTick() - client.getTickCount();
 		int millisLeft = ticksLeft * 600;
 		return (int) (millisLeft / 1000L);
 	}

--- a/src/main/java/com/cluedetails/ClueGroundSaveDataManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundSaveDataManager.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import net.runelite.api.Client;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.config.ConfigManager;
 
@@ -53,28 +52,26 @@ public class ClueGroundSaveDataManager
 		this.gson = gson;
 	}
 
-	public void saveStateToConfig(Client client, List<ClueInstance> groundClues)
+	public void saveStateToConfig(List<ClueInstance> groundClues)
 	{
 		// Serialize groundClues save to config
-		updateData(client, groundClues);
+		updateData(groundClues);
 		String groundCluesJson = gson.toJson(clueInstanceData);
 		configManager.setConfiguration(CONFIG_GROUP, GROUND_CLUES_KEY, groundCluesJson);
 	}
 
-	private void updateData(Client client, List<ClueInstance> groundClues)
+	private void updateData(List<ClueInstance> groundClues)
 	{
-		int currentTick = client.getTickCount();
-
 		List<ClueInstanceData> newData = new ArrayList<>();
 		for (ClueInstance groundClue : groundClues)
 		{
-			newData.add(new ClueInstanceData(groundClue, currentTick));
+			newData.add(new ClueInstanceData(groundClue));
 		}
 		clueInstanceData.clear();
 		clueInstanceData.addAll(newData);
 	}
 
-	public Map<WorldPoint, List<ClueInstance>> loadStateFromConfig(Client client)
+	public Map<WorldPoint, List<ClueInstance>> loadStateFromConfig()
 	{
 		String groundCluesJson = configManager.getConfiguration(CONFIG_GROUP, GROUND_CLUES_KEY);
 		clueInstanceData.clear();
@@ -111,7 +108,7 @@ public class ClueGroundSaveDataManager
 			} catch (Exception err)
 			{
 				groundClues.clear();
-				saveStateToConfig(client, new ArrayList<>());
+				saveStateToConfig(new ArrayList<>());
 			}
 		}
 

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -206,7 +206,7 @@ public class ClueInstance
 		return color;
 	}
 
-	public int getDespawnTick(int currentTick)
+	public int getDespawnTick()
 	{
 		if (tileItem != null)
 		{
@@ -310,8 +310,8 @@ public class ClueInstance
 		}
 		else if (tileItem == null && clueInstance.tileItem == null)
 		{
-			diff1 = getDespawnTick(ClueDetailsPlugin.getCurrentTick());
-			diff2 = clueInstance.getDespawnTick(ClueDetailsPlugin.getCurrentTick());
+			diff1 = getDespawnTick();
+			diff2 = clueInstance.getDespawnTick();
 		}
 		else
 		{
@@ -325,14 +325,14 @@ public class ClueInstance
 	@Override
 	public int hashCode()
 	{
-		int despawnTime = getDespawnTick(ClueDetailsPlugin.getCurrentTick());
+		int despawnTime = getDespawnTick();
 		return Objects.hash(itemId, despawnTime, location);
 	}
 
 	@Override
 	public String toString()
 	{
-		int despawnTime = getDespawnTick(ClueDetailsPlugin.getCurrentTick());
+		int despawnTime = getDespawnTick();
 		return "ClueInstance{" + "itemId=" + itemId + ", despawnTick=" + despawnTime + ", worldPoint=" + location + ", orderId=" + sequenceNumber + "}";
 	}
 }

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -212,7 +212,7 @@ public class ClueInstance
 		{
 			return tileItem.getDespawnTime();
 		}
-		return currentTick + timeToDespawnFromDataInTicks;
+		return timeToDespawnFromDataInTicks;
 	}
 
 	// Theory: This should mean that tiles we've seen have TileItem, and the actual despawn is used for ALL items on that tile

--- a/src/main/java/com/cluedetails/ClueInstanceData.java
+++ b/src/main/java/com/cluedetails/ClueInstanceData.java
@@ -42,7 +42,7 @@ public class ClueInstanceData
 	{
 		this.clueIds = clue.getClueIds();
 		this.itemId = clue.getItemId();
-		this.despawnTick = clue.getTicksToDespawnConsideringTileItem(currentTick);
+		this.despawnTick = clue.getDespawnTick(currentTick);
 		if (clue.getLocation() == null) return;
 
 		this.x = clue.getLocation().getX();

--- a/src/main/java/com/cluedetails/ClueInstanceData.java
+++ b/src/main/java/com/cluedetails/ClueInstanceData.java
@@ -38,11 +38,11 @@ public class ClueInstanceData
 	private int y;
 	private int plane;
 
-	public ClueInstanceData(ClueInstance clue, int currentTick)
+	public ClueInstanceData(ClueInstance clue)
 	{
 		this.clueIds = clue.getClueIds();
 		this.itemId = clue.getItemId();
-		this.despawnTick = clue.getDespawnTick(currentTick);
+		this.despawnTick = clue.getDespawnTick();
 		if (clue.getLocation() == null) return;
 
 		this.x = clue.getLocation().getX();

--- a/src/main/java/com/cluedetails/WorldPointToClueInstances.java
+++ b/src/main/java/com/cluedetails/WorldPointToClueInstances.java
@@ -56,7 +56,7 @@ public class WorldPointToClueInstances
 
 		clueComparator = Comparator
 			.comparingLong(ClueInstance::getSequenceNumber)
-			.thenComparingInt((ClueInstance oc) -> oc.getDespawnTick(client.getTickCount()));
+			.thenComparingInt(ClueInstance::getDespawnTick);
 	}
 
 	private void createGroupedSet(WorldPoint wp)
@@ -214,7 +214,7 @@ public class WorldPointToClueInstances
 	{
 		for (ClueInstance clueInstance : getAllClues())
 		{
-			if (clueInstance.getDespawnTick(client.getTickCount()) <= client.getTickCount())
+			if (clueInstance.getDespawnTick() <= client.getTickCount())
 			{
 				removeClue(clueInstance);
 			}


### PR DESCRIPTION
Currently, despawnTimers per ClueInstance (particularly when used for Ground Clue Timers) "freeze" when not associated with a tileItem

Initial testing did not uncover any issues caused by this change, but please inform of any edge cases I should test.