### PR TITLE
fix: Shift despawn tick by 1 down for new items

### DIFF
--- a/src/main/java/com/cluedetails/ClueGroundManager.java
+++ b/src/main/java/com/cluedetails/ClueGroundManager.java
@@ -99,7 +99,7 @@ public class ClueGroundManager
 		// If clue in inventory AND new clue appeared with fresh despawn timer, it must be the inventory item being dropped
 		if (isNewGroundClue(item.getId(), item.getDespawnTime()) && inventoryClue != null)
 		{
-			ClueInstance newGroundClue = new ClueInstance(inventoryClue.getClueIds(), inventoryClue.getItemId(), tile.getWorldLocation(), item, client.getTickCount());
+			ClueInstance newGroundClue = new ClueInstance(inventoryClue.getClueIds(), inventoryClue.getItemId(), tile.getWorldLocation(), item, true);
 			trackedClues.addClue(newGroundClue);
 			return;
 		}

--- a/src/main/java/com/cluedetails/ClueInstance.java
+++ b/src/main/java/com/cluedetails/ClueInstance.java
@@ -57,6 +57,7 @@ public class ClueInstance
 	@Getter
 	private final Integer timeToDespawnFromDataInTicks;
 	private TileItem tileItem;
+	private boolean isNewClue;
 
 	// Constructor for clues from config
 	public ClueInstance(ClueInstanceData data)
@@ -90,7 +91,19 @@ public class ClueInstance
 		this.itemId = itemId;
 		this.location = location;
 		this.tileItem = tileItem;
-		this.timeToDespawnFromDataInTicks = currentTick;
+		this.timeToDespawnFromDataInTicks = tileItem.getDespawnTime();
+
+		this.sequenceNumber = sequenceGenerator.getAndIncrement();
+	}
+
+	public ClueInstance(List<Integer> clueIds, int itemId, WorldPoint location, TileItem tileItem, boolean isNewClue)
+	{
+		this.clueIds = clueIds;
+		this.itemId = itemId;
+		this.location = location;
+		this.tileItem = tileItem;
+		this.timeToDespawnFromDataInTicks = tileItem.getDespawnTime() - 1;
+		this.isNewClue = isNewClue;
 
 		this.sequenceNumber = sequenceGenerator.getAndIncrement();
 	}
@@ -144,7 +157,14 @@ public class ClueInstance
 
 		if (clueIds.isEmpty())
 		{
-			clueText = WordUtils.capitalizeFully(this.getTier().toString().replace("_", " "));
+			if (this.getTier() == null)
+			{
+				clueText = "";
+			}
+			else
+			{
+				clueText = WordUtils.capitalizeFully(this.getTier().toString().replace("_", " "));
+			}
 		}
 		else
 		{
@@ -210,7 +230,9 @@ public class ClueInstance
 	{
 		if (tileItem != null)
 		{
-			return tileItem.getDespawnTime();
+			int subValue = 0;
+			if (isNewClue) subValue = 1;
+			return tileItem.getDespawnTime() - subValue;
 		}
 		return timeToDespawnFromDataInTicks;
 	}


### PR DESCRIPTION
This ensure the relative despawn tick for all items is the same.

For some reason for a TileItem for a freshly spawned item, the despawnTime is the tick the item will go away. For a non-fresh spawned item, it's the tick before it'll despawn. Technically slightly more correct to move old items to a tick ahead, but this simplifies the code change a lot to just remove a tick from fresh spawn items.

fixes #149.