### PR TITLE
fix: Inventory overlay

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsInventoryOverlay.java
+++ b/src/main/java/com/cluedetails/ClueDetailsInventoryOverlay.java
@@ -73,29 +73,32 @@ public class ClueDetailsInventoryOverlay extends OverlayPanel
 	private void createInventoryCluesOverlay()
 	{
 		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
-		if (inventory == null) return;
+		if (inventory == null || clueInventoryManager == null ) return;
 
-		for (Item item : inventory.getItems())
+		for (Integer itemID : clueInventoryManager.getCluesInInventory())
 		{
-			ClueInstance clueInstance = clueInventoryManager.getClueByClueItemId(item.getId());
-			if (clueInstance == null || clueInstance.getClueIds().isEmpty()) continue;
+			if (itemID == null) continue;
+			ClueInstance instance = clueInventoryManager.getClueByClueItemId(itemID);
+			if (instance == null) continue;
 
-			for (Integer clueId : clueInstance.getClueIds())
+			instance.getClueIds().forEach((clueId) ->
 			{
-				Clues cluePart = Clues.forClueIdFiltered(clueId);
-				if (cluePart == null) continue;
-
 				Color color = TITLED_CONTENT_COLOR;
-				if (config.colorInventoryCluesOverlay())
+				Clues clue = Clues.forClueIdFiltered(clueId);
+				if (clue == null) return;
+				if (clue.isEnabled(config))
 				{
-					color = cluePart.getDetailColor(configManager);
-				}
+					if (config.colorInventoryCluesOverlay())
+					{
+						color = clue.getDetailColor(configManager);
+					}
 
-				panelComponent.getChildren().add(LineComponent.builder()
-					.left(cluePart.getDetail(configManager))
-					.leftColor(color)
-					.build());
-			}
+					panelComponent.getChildren().add(LineComponent.builder()
+						.left(clue.getDetail(configManager))
+						.leftColor(color)
+						.build());
+				}
+			});
 		}
 	}
 }

--- a/src/main/java/com/cluedetails/Clues.java
+++ b/src/main/java/com/cluedetails/Clues.java
@@ -1244,6 +1244,7 @@ public class Clues
 
 		itemIdClueCache = enabledClues
 				.stream()
+				.filter(clue -> clue.getItemID() >= 2677) // Ignore InterfaceID and HotColdLocation
 				.collect(Collectors.groupingBy(Clues::getItemID));
 
 		clueIdClueCache = enabledClues


### PR DESCRIPTION
Closes #168

1. Adding `HotColdLocation` values caused `itemIdClueCache` to be populated incorrectly
2. Updated Inventory Overlay to match how `ClueDetailsItemsOverlay` is populated -- respects tier toggles