### PR TITLE
Auto-scroll improvements

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsConfig.java
+++ b/src/main/java/com/cluedetails/ClueDetailsConfig.java
@@ -840,11 +840,20 @@ public interface ClueDetailsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "autoScrollCaseSensitivity",
+		name = "Auto-scroll case sensitivity",
+		description = "If enabled, only codes in all-caps will be detected (eg. AIQ, HIDEOUT).",
+		section = helperSection,
+		position = 5
+	)
+	default boolean autoScrollCaseSensitivity() { return true; }
+
+	@ConfigItem(
 		keyName = "inventoryClueChatMessages",
 		name = "Inventory clue chat messages",
 		description = "Sends a console message containing the Clue Detail text when an identified clue enters your inventory",
 		section = helperSection,
-		position = 5
+		position = 6
 	)
 	default boolean inventoryClueChatMessages()
 	{

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -234,8 +234,10 @@ public class ClueDetailsPlugin extends Plugin
 	@Getter @Setter
 	private boolean fairyRingOpen = false;
 
-	// Case-insensitive. Matches first occurrence of a validly formed fairy ring code or the word hideout.
-	private final Pattern fairyRingPattern = Pattern.compile("(?i)(?:^|.*?\\b)(?<code>[A-D][I-L][P-S]|HIDEOUT)(?:$|\\b.*)");
+	// Matches first occurrence of a validly formed fairy ring code or the word hideout.
+	private final String fairyRingRegex = "(?:^|.*?\\b)(?<code>[A-D][I-L][P-S]|HIDEOUT)(?:$|\\b.*)";
+	private final Pattern fairyRingPattern = Pattern.compile(fairyRingRegex);
+	private final Pattern fairyRingPatternInsensitive = Pattern.compile(fairyRingRegex, Pattern.CASE_INSENSITIVE);
 
 	@Override
 	protected void startUp() throws Exception
@@ -805,7 +807,7 @@ public class ClueDetailsPlugin extends Plugin
 		// Find the first (from top left) inventory clue with a valid-formatted fairy-ring code
 		return cluesInInventoryText.stream()
 			.map(clueText -> {
-				Matcher m = fairyRingPattern.matcher(clueText);
+				Matcher m = config.autoScrollCaseSensitivity() ? fairyRingPattern.matcher(clueText) : fairyRingPatternInsensitive.matcher(clueText);
 				return m.matches() ? m.group("code") : null;
 			})
 			.filter(Objects::nonNull)
@@ -816,6 +818,7 @@ public class ClueDetailsPlugin extends Plugin
 	private boolean codeWidgetMatches(Widget codeWidget, String code)
 	{
 		String codeWidgetCode = codeWidget.getText().replace(" ","");
+		// Config check is unneeded here
 		return codeWidgetCode.equalsIgnoreCase(code) || codeWidgetCode.equalsIgnoreCase("(Clue)" + code);
 	}
 
@@ -829,7 +832,7 @@ public class ClueDetailsPlugin extends Plugin
 		if (fairyRingCode == null) return null;
 
 		// Don't need to search for hideout
-		if (fairyRingCode.equalsIgnoreCase("hideout")) return client.getWidget(InterfaceID.FairyringsLog.HIDEOUT);
+		if (fairyRingCode.equalsIgnoreCase("HIDEOUT")) return client.getWidget(InterfaceID.FairyringsLog.HIDEOUT);
 
 		// Search through favourited fairy rings by ID
 		for (int faveId = InterfaceID.FairyringsLog.FAVE_CODE_1; faveId <= InterfaceID.FairyringsLog.FAVE_CODE_10; faveId++)

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -30,6 +30,7 @@ import com.google.gson.Gson;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -85,6 +86,7 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdLocation;
+import net.runelite.client.plugins.fairyring.FairyRing;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
@@ -239,6 +241,8 @@ public class ClueDetailsPlugin extends Plugin
 	private final Pattern fairyRingPattern = Pattern.compile(fairyRingRegex);
 	private final Pattern fairyRingPatternInsensitive = Pattern.compile(fairyRingRegex, Pattern.CASE_INSENSITIVE);
 
+	private final HashSet<String> validFairyRings = new HashSet<>();
+
 	@Override
 	protected void startUp() throws Exception
 	{
@@ -248,6 +252,8 @@ public class ClueDetailsPlugin extends Plugin
 		clueGroundManager.startUp();
 
 		Clues.rebuildFilteredCluesCache();
+
+		populateValidFairyRings();
 
 		final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "/icon.png");
 
@@ -805,11 +811,16 @@ public class ClueDetailsPlugin extends Plugin
 
 		if (cluesInInventoryText.isEmpty()) return null;
 
-		// Find the first (from top left) inventory clue with a valid-formatted fairy-ring code
+		// Find the first (from top left) inventory clue with a valid fairy-ring code
 		return cluesInInventoryText.stream()
 			.map(clueText -> {
 				Matcher m = config.autoScrollCaseSensitivity() ? fairyRingPattern.matcher(clueText) : fairyRingPatternInsensitive.matcher(clueText);
-				return m.matches() ? m.group("code").replace(" ", "") : null;
+				if (m.matches())
+				{
+					String matchedRing = m.group("code").replace(" ", "");
+					return validFairyRings.contains(matchedRing) ? matchedRing : null;
+				}
+				return null;
 			})
 			.filter(Objects::nonNull)
 			.findFirst()
@@ -869,5 +880,14 @@ public class ClueDetailsPlugin extends Plugin
 		{
 			foundCodeWidget.setText("(Clue) " + foundCodeWidget.getText());
 		}
+	}
+
+	private void populateValidFairyRings()
+	{
+		for (FairyRing fairyRing : FairyRing.values())
+		{
+			validFairyRings.add(fairyRing.name());
+		}
+		validFairyRings.add("HIDEOUT");
 	}
 }

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -235,7 +235,7 @@ public class ClueDetailsPlugin extends Plugin
 	private boolean fairyRingOpen = false;
 
 	// Matches first occurrence of a validly formed fairy ring code or the word hideout.
-	private final String fairyRingRegex = "(?:^|.*?\\b)(?<code>[A-D][I-L][P-S]|HIDEOUT)(?:$|\\b.*)";
+	private final String fairyRingRegex = "(?:^|.*?\\b)(?<code>[A-D][I-L][P-S]|[A-D] [I-L] [P-S]|HIDEOUT)(?:$|\\b.*)";
 	private final Pattern fairyRingPattern = Pattern.compile(fairyRingRegex);
 	private final Pattern fairyRingPatternInsensitive = Pattern.compile(fairyRingRegex, Pattern.CASE_INSENSITIVE);
 
@@ -808,7 +808,7 @@ public class ClueDetailsPlugin extends Plugin
 		return cluesInInventoryText.stream()
 			.map(clueText -> {
 				Matcher m = config.autoScrollCaseSensitivity() ? fairyRingPattern.matcher(clueText) : fairyRingPatternInsensitive.matcher(clueText);
-				return m.matches() ? m.group("code") : null;
+				return m.matches() ? m.group("code").replace(" ", "") : null;
 			})
 			.filter(Objects::nonNull)
 			.findFirst()

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -30,12 +30,13 @@ import com.google.gson.Gson;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.TreeMap;
 import javax.inject.Inject;
@@ -84,7 +85,6 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdLocation;
-import net.runelite.client.plugins.fairyring.FairyRing;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
@@ -233,6 +233,9 @@ public class ClueDetailsPlugin extends Plugin
 
 	@Getter @Setter
 	private boolean fairyRingOpen = false;
+
+	// Case-insensitive. Matches first occurrence of a validly formed fairy ring code or the word hideout.
+	private final Pattern fairyRingPattern = Pattern.compile("(?i)(?:^|.*?\\b)(?<code>[A-D][I-L][P-S]|HIDEOUT)(?:$|\\b.*)");
 
 	@Override
 	protected void startUp() throws Exception
@@ -799,11 +802,21 @@ public class ClueDetailsPlugin extends Plugin
 
 		if (cluesInInventoryText.isEmpty()) return null;
 
-		// Find the first-declared fairy ring for clues in inventory
-		return String.valueOf(Arrays.stream(FairyRing.values())
-			.filter(code -> cluesInInventoryText.stream().anyMatch(text -> text.contains(code.toString())))
+		// Find the first (from top left) inventory clue with a valid-formatted fairy-ring code
+		return cluesInInventoryText.stream()
+			.map(clueText -> {
+				Matcher m = fairyRingPattern.matcher(clueText);
+				return m.matches() ? m.group("code") : null;
+			})
+			.filter(Objects::nonNull)
 			.findFirst()
-			.orElse(null));
+			.orElse(null);
+	}
+
+	private boolean codeWidgetMatches(Widget codeWidget, String code)
+	{
+		String codeWidgetCode = codeWidget.getText().replace(" ","");
+		return codeWidgetCode.equalsIgnoreCase(code) || codeWidgetCode.equalsIgnoreCase("(Clue)" + code);
 	}
 
 	/**
@@ -813,19 +826,16 @@ public class ClueDetailsPlugin extends Plugin
 	{
 		String fairyRingCode = getFirstFairyRingCodeInInventoryClues();
 
+		if (fairyRingCode == null) return null;
+
+		// Don't need to search for hideout
+		if (fairyRingCode.equalsIgnoreCase("hideout")) return client.getWidget(InterfaceID.FairyringsLog.HIDEOUT);
+
 		// Search through favourited fairy rings by ID
 		for (int faveId = InterfaceID.FairyringsLog.FAVE_CODE_1; faveId <= InterfaceID.FairyringsLog.FAVE_CODE_10; faveId++)
 		{
 			Widget codeWidget = client.getWidget(faveId);
-			if (codeWidget != null)
-			{
-				String codeWidgetCode = codeWidget.getText().replace(" ","");
-
-				if (codeWidgetCode.equals(fairyRingCode) || codeWidgetCode.equals("(Clue)" + fairyRingCode))
-				{
-					return codeWidget;
-				}
-			}
+			if (codeWidget != null && codeWidgetMatches(codeWidget, fairyRingCode)) return codeWidget;
 		}
 
 		Widget codeWidgets = client.getWidget(InterfaceID.FairyringsLog.CONTENTS);
@@ -836,13 +846,7 @@ public class ClueDetailsPlugin extends Plugin
 
 		for (Widget codeWidget : codeWidgetDynamicChildren)
 		{
-			String codeWidgetCode = codeWidget.getText().replace(" ","");
-
-			if(codeWidgetCode.equals(fairyRingCode)
-				|| codeWidgetCode.equals("(Clue)"+fairyRingCode))
-			{
-				return codeWidget;
-			}
+			if (codeWidgetMatches(codeWidget, fairyRingCode)) return codeWidget;
 		}
 		return null;
 	}

--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -769,7 +769,8 @@ public class ClueDetailsPlugin extends Plugin
 		if (fairyRingCode == null) return true;
 
 		Widget foundCodeWidget = findCodeWidget();
-		if (foundCodeWidget == null) return false;
+		// If widget is not found (due to search etc) then rerun only if the panel is open
+		if (foundCodeWidget == null) return !isFairyRingOpen();
 
 		// Scroll to the code entry and highlight it
 		int panelScrollY = (foundCodeWidget.getRelativeY());


### PR DESCRIPTION
Features added:
 - Support fairy queen hideout.
 - Config toggleable case-insensitivity, defaults to current behaviour (case-sensitive).
 - Can format codes with spaces like the fairy ring interface.

Fixes:
 - Searches inventory clues from top-left to bottom-right (previously got lexicographically first code that was present on any clue).
 - Now matches first instance of ring code in clue text (previously was lexicographically first code).
 - #200 

Todo:
 - ~~Config toggle for case insensitivity in case someone puts their codes at the end of the clues.~~
 - ~~Validation on the detected ring code? Seems less important than the above.~~