### PR TITLE
fix: clue right-click editing for sway

### DIFF
--- a/src/main/java/com/cluedetails/panels/ClueDetailsParentPanel.java
+++ b/src/main/java/com/cluedetails/panels/ClueDetailsParentPanel.java
@@ -77,7 +77,6 @@ public class ClueDetailsParentPanel extends PluginPanel
 	private JTable clueTable;
 	@Getter
 	private int hoveredRow = -1;
-	private int rightClickedRow = -1;
 	private final IconTextField searchBar = new IconTextField();
 	private List<ListItem> allClues = new ArrayList<>();
 
@@ -196,10 +195,6 @@ public class ClueDetailsParentPanel extends PluginPanel
 					cluePreferenceManager.saveHighlightPreference(clue.getClueID(), newState);
 					clueTable.repaint();
 				}
-				else if (SwingUtilities.isRightMouseButton(e))
-				{
-					rightClickedRow = row;
-				}
 			}
 
 			@Override
@@ -263,8 +258,9 @@ public class ClueDetailsParentPanel extends PluginPanel
 		JMenuItem inputTextItem = new JMenuItem("Edit text for clue");
 		inputTextItem.addActionListener(event ->
 		{
-			clueTableModel.setEditableRow(rightClickedRow);
-			clueTable.editCellAt(rightClickedRow, 0);
+			var selectedRow = clueTable.getSelectedRow();
+			clueTableModel.setEditableRow(selectedRow);
+			clueTable.editCellAt(selectedRow, 0);
 			Component editorComponent = clueTable.getEditorComponent();
 			if (editorComponent != null)
 			{
@@ -276,7 +272,7 @@ public class ClueDetailsParentPanel extends PluginPanel
 		JMenuItem inputColorItem = new JMenuItem("Edit color for clue");
 		inputColorItem.addActionListener(event ->
 		{
-			ListItem item = (ListItem) clueTableModel.getValueAt(rightClickedRow, 0);
+			ListItem item = (ListItem) clueTableModel.getValueAt(clueTable.getSelectedRow(), 0);
 			Clues clue = item.getClue();
 			int clueItemId = clue.getItemID();
 			int clueClueID = clue.getClueID();
@@ -331,7 +327,7 @@ public class ClueDetailsParentPanel extends PluginPanel
 		JMenuItem inputItems = new JMenuItem(inputItemsTooltip);
 		inputItems.addActionListener(event ->
 		{
-			ListItem item = (ListItem) clueTableModel.getValueAt(rightClickedRow, 0);
+			ListItem item = (ListItem) clueTableModel.getValueAt(clueTable.getSelectedRow(), 0);
 			Clues clue = item.getClue();
 
 			ChatboxItemSearch itemSearch = getItemSearch(inputItemsTooltip);

--- a/src/main/java/com/cluedetails/panels/ClueJTable.java
+++ b/src/main/java/com/cluedetails/panels/ClueJTable.java
@@ -25,6 +25,8 @@
 package com.cluedetails.panels;
 
 import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.event.MouseEvent;
 import java.util.EventObject;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
@@ -45,6 +47,25 @@ public class ClueJTable extends JTable
 		setSurrendersFocusOnKeystroke(false);
 		setCellSelectionEnabled(false);
 		setFocusable(false);
+	}
+
+	@Override
+	public Point getPopupLocation(MouseEvent e)
+	{
+		if (e != null)
+		{
+			var viewRow = rowAtPoint(e.getPoint());
+			if (viewRow >= 0)
+			{
+				setRowSelectionInterval(viewRow, viewRow);
+			}
+			else
+			{
+				clearSelection();
+			}
+		}
+
+		return super.getPopupLocation(e);
 	}
 
 	@Override


### PR DESCRIPTION
Prior to this pull request, on my system (arch linux btw, sway/wayland), the right-click menu did not work consistently. _usually_ the right-click "edit text" would not work at all (rightClickIndex was -1), or something it would get set and right-clicking row 5 would edit row 3 that i clicked before.

this change moves the menu-row-selection into the JTable's `getPopupLocation` call which is called before the menu shows up and instead sets the selected row on the table itself.

### i have not tested this on macos or windows!!
