### PR TITLE
fix: Only modify idle timeout if related config is enabled

### DIFF
--- a/src/main/java/com/cluedetails/ClueDetailsPlugin.java
+++ b/src/main/java/com/cluedetails/ClueDetailsPlugin.java
@@ -753,8 +753,11 @@ public class ClueDetailsPlugin extends Plugin
 
 	private void resetIdleTimeout()
 	{
+		// Only modify idle timeout if related config is enabled
+		if (!config.decreaseIdleTimeout()) return;
+
 		String minutes_config = configManager.getConfiguration("logouttimer", "idleTimeout");
-		int minutes_parsed = 25;
+		int minutes_parsed = 30; // Reset to max idle timeout if idleTimeout cannot be parsed
 		if (minutes_config != null)
 		{
 			minutes_parsed = Integer.parseInt(minutes_config);


### PR DESCRIPTION
Closes #203

Jagex has since updated max idle timeout from 25 to 30 minutes